### PR TITLE
Add sosreport MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ For connecting to the MCP server, the following steps are required:
 make build
 ```
 
+The server supports 2 operating modes:
+- `live-cluster` (default): Connect to a live Kubernetes cluster for real-time debugging
+- `offline`: Offline troubleshooting without requiring cluster access
+
 The server currently supports 2 transport modes: `stdio` and `http`.
+
+### Live Cluster Mode
 
 For `stdio` mode, the server can be run and connected to by using the following configuration in an MCP host (Cursor, Claude, etc.):
 
@@ -27,7 +33,7 @@ For `stdio` mode, the server can be run and connected to by using the following 
 }
 ```
 
-For `http` mode, the server should be started separately.
+For `http` mode, the server should be started separately:
 
 ```shell
 ./PATH-TO-THE-LOCAL-GIT-REPO/_output/ovnk-mcp-server --transport http --kubeconfig /PATH-TO-THE-KUBECONFIG-FILE
@@ -43,4 +49,27 @@ The following configuration should be used in an MCP host (Cursor, Claude, etc.)
     }
   }
 }
+```
+
+### Offline Mode
+
+For offline troubleshooting (e.g., analyzing sosreports), use `--mode offline`:
+
+For `stdio` mode:
+
+```json
+{
+  "mcpServers": {
+    "ovn-kubernetes": {
+      "command": "/PATH-TO-THE-LOCAL-GIT-REPO/_output/ovnk-mcp-server",
+      "args": ["--mode", "offline"]
+    }
+  }
+}
+```
+
+For `http` mode:
+
+```shell
+./PATH-TO-THE-LOCAL-GIT-REPO/_output/ovnk-mcp-server --transport http --mode offline
 ```

--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -12,6 +12,7 @@ import (
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
+	sosreportmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/mcp"
 )
 
 type MCPServerConfig struct {
@@ -36,6 +37,11 @@ func main() {
 		}
 		log.Println("Adding Kubernetes tools to OVN-K MCP server")
 		k8sMcpServer.AddTools(ovnkMcpServer)
+	}
+	if serverCfg.Mode == "offline" {
+		sosreportServer := sosreportmcp.NewMCPServer()
+		log.Println("Adding sosreport tools to OVN-K MCP server")
+		sosreportServer.AddTools(ovnkMcpServer)
 	}
 
 	// Create a context that can be cancelled to shutdown the server.

--- a/pkg/sosreport/mcp/commands.go
+++ b/pkg/sosreport/mcp/commands.go
@@ -1,0 +1,149 @@
+package sosreport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/types"
+)
+
+const (
+	// defaultResultLimit is the default maximum number of lines/results to return
+	defaultResultLimit = 100
+)
+
+// getCommandOutput reads a command output file by filepath from manifest
+func getCommandOutput(sosreportPath, relativeFilepath, pattern string, maxLines int) (string, error) {
+	if err := validateSosreportPath(sosreportPath); err != nil {
+		return "", err
+	}
+
+	if err := validateRelativePath(relativeFilepath); err != nil {
+		return "", err
+	}
+
+	fullPath := filepath.Join(sosreportPath, relativeFilepath)
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("command output file not found: %s", relativeFilepath)
+	}
+
+	file, err := os.Open(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	var searchPattern *regexp.Regexp
+	if pattern != "" {
+		searchPattern, err = regexp.Compile(pattern)
+		if err != nil {
+			return "", fmt.Errorf("invalid pattern: %w", err)
+		}
+	}
+
+	if maxLines <= 0 {
+		maxLines = defaultResultLimit
+	}
+
+	output, err := readWithLimit(file, searchPattern, maxLines)
+	if err != nil {
+		return "", err
+	}
+
+	if output == "" && pattern != "" {
+		return fmt.Sprintf("No lines matching pattern %q found\n", pattern), nil
+	}
+
+	return output, nil
+}
+
+// listPlugins returns a list of enabled plugins with their command counts
+func listPlugins(sosreportPath string) (types.ListPluginsResult, error) {
+	manifest, err := loadManifest(sosreportPath)
+	if err != nil {
+		return types.ListPluginsResult{}, err
+	}
+
+	var result types.ListPluginsResult
+	totalCommands := 0
+
+	// Only show enabled plugins
+	for pluginName, plugin := range manifest.Components.Report.Plugins {
+		commandCount := len(plugin.Commands)
+		totalCommands += commandCount
+
+		result.Plugins = append(result.Plugins, types.PluginSummary{
+			Name:         pluginName,
+			CommandCount: commandCount,
+		})
+	}
+
+	result.TotalCommands = totalCommands
+	return result, nil
+}
+
+// listCommands returns all commands for a specific plugin
+func listCommands(sosreportPath, pluginName string) (types.ListCommandsResult, error) {
+	manifest, err := loadManifest(sosreportPath)
+	if err != nil {
+		return types.ListCommandsResult{}, err
+	}
+
+	plugin, exists := manifest.Components.Report.Plugins[pluginName]
+	if !exists {
+		return types.ListCommandsResult{}, fmt.Errorf("plugin %q not found in manifest", pluginName)
+	}
+
+	result := types.ListCommandsResult{
+		Plugin:       pluginName,
+		CommandCount: len(plugin.Commands),
+	}
+
+	for _, cmd := range plugin.Commands {
+		result.Commands = append(result.Commands, types.CommandSummary{
+			Exec:     cmd.Exec,
+			Filepath: cmd.Filepath,
+		})
+	}
+
+	return result, nil
+}
+
+// searchCommands searches for commands matching a pattern across all plugins
+func searchCommands(sosreportPath, pattern string, maxResults int) (types.SearchCommandsResult, error) {
+	manifest, err := loadManifest(sosreportPath)
+	if err != nil {
+		return types.SearchCommandsResult{}, err
+	}
+
+	searchPattern, err := regexp.Compile(pattern)
+	if err != nil {
+		return types.SearchCommandsResult{}, fmt.Errorf("invalid search pattern: %w", err)
+	}
+
+	var result types.SearchCommandsResult
+	if maxResults <= 0 {
+		maxResults = defaultResultLimit
+	}
+
+	for pluginName, plugin := range manifest.Components.Report.Plugins {
+		for _, cmd := range plugin.Commands {
+			if searchPattern.MatchString(cmd.Exec) || searchPattern.MatchString(cmd.Filepath) {
+				result.Matches = append(result.Matches, types.CommandMatch{
+					Plugin:   pluginName,
+					Exec:     cmd.Exec,
+					Filepath: cmd.Filepath,
+				})
+
+				if len(result.Matches) >= maxResults {
+					result.Total = len(result.Matches)
+					return result, nil
+				}
+			}
+		}
+	}
+
+	result.Total = len(result.Matches)
+	return result, nil
+}

--- a/pkg/sosreport/mcp/commands_test.go
+++ b/pkg/sosreport/mcp/commands_test.go
@@ -1,0 +1,370 @@
+package sosreport
+
+import (
+	"strings"
+	"testing"
+)
+
+const sosreportTestData = "testdata/sosreport"
+
+func TestGetCommandOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		sosreport    string
+		filepath     string
+		pattern      string
+		maxLines     int
+		wantError    bool
+		errorMsg     string
+		wantContains string
+		wantMinLines int
+		wantMaxLines int
+	}{
+		{
+			name:         "get ovs-vsctl output without pattern",
+			sosreport:    sosreportTestData,
+			filepath:     "sos_commands/openvswitch/ovs-vsctl_-t_5_show",
+			pattern:      "",
+			maxLines:     0,
+			wantError:    false,
+			wantContains: "Bridge br-int",
+			wantMinLines: 1,
+		},
+		{
+			name:         "get ovs-ofctl output without pattern",
+			sosreport:    sosreportTestData,
+			filepath:     "sos_commands/openvswitch/ovs-ofctl_dump-flows_br-int",
+			pattern:      "",
+			maxLines:     0,
+			wantError:    false,
+			wantContains: "cookie=0x0",
+			wantMinLines: 1,
+		},
+		{
+			name:         "get ip addr show output",
+			sosreport:    sosreportTestData,
+			filepath:     "sos_commands/networking/ip_addr_show",
+			pattern:      "",
+			maxLines:     0,
+			wantError:    false,
+			wantContains: "lo:",
+			wantMinLines: 1,
+		},
+		{
+			name:         "filter with pattern no matches",
+			sosreport:    sosreportTestData,
+			filepath:     "sos_commands/networking/ip_addr_show",
+			pattern:      "NOTFOUND",
+			maxLines:     0,
+			wantError:    false,
+			wantContains: "No lines matching pattern",
+			wantMinLines: 1,
+		},
+		{
+			name:         "limit max lines",
+			sosreport:    sosreportTestData,
+			filepath:     "sos_commands/networking/ip_addr_show",
+			pattern:      "",
+			maxLines:     2,
+			wantError:    false,
+			wantContains: "output truncated",
+			wantMaxLines: 2,
+		},
+		{
+			name:      "non-existent file",
+			sosreport: sosreportTestData,
+			filepath:  "sos_commands/non-existent-file",
+			pattern:   "",
+			maxLines:  0,
+			wantError: true,
+			errorMsg:  "command output file not found",
+		},
+		{
+			name:      "invalid sosreport path",
+			sosreport: "testdata/non-existent",
+			filepath:  "sos_commands/openvswitch/ovs-vsctl_-t_5_show",
+			pattern:   "",
+			maxLines:  0,
+			wantError: true,
+			errorMsg:  "sosreport path does not exist",
+		},
+		{
+			name:      "invalid regex pattern",
+			sosreport: sosreportTestData,
+			filepath:  "sos_commands/networking/ip_addr_show",
+			pattern:   "[invalid(",
+			maxLines:  0,
+			wantError: true,
+			errorMsg:  "invalid pattern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := getCommandOutput(tt.sosreport, tt.filepath, tt.pattern, tt.maxLines)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("getCommandOutput() expected error but got nil")
+				} else if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("getCommandOutput() error = %v, want error containing %q", err, tt.errorMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("getCommandOutput() unexpected error = %v", err)
+				return
+			}
+
+			// Check for expected content
+			if tt.wantContains != "" && !strings.Contains(output, tt.wantContains) {
+				t.Errorf("getCommandOutput() output does not contain %q, got:\n%s", tt.wantContains, output)
+			}
+
+			// Check line count if specified (excluding truncation message and empty lines)
+			if tt.wantMinLines > 0 || tt.wantMaxLines > 0 {
+				lines := strings.Split(output, "\n")
+				lineCount := 0
+				for _, line := range lines {
+					if line != "" && !strings.Contains(line, "output truncated") && !strings.HasPrefix(line, "...") {
+						lineCount++
+					}
+				}
+
+				if tt.wantMinLines > 0 && lineCount < tt.wantMinLines {
+					t.Errorf("getCommandOutput() got %d lines, want at least %d", lineCount, tt.wantMinLines)
+				}
+
+				if tt.wantMaxLines > 0 && lineCount > tt.wantMaxLines {
+					t.Errorf("getCommandOutput() got %d lines, want at most %d. Output:\n%s", lineCount, tt.wantMaxLines, output)
+				}
+			}
+		})
+	}
+}
+
+func TestListPlugins(t *testing.T) {
+	tests := []struct {
+		name            string
+		path            string
+		wantError       bool
+		wantPluginCount int
+		wantTotalCmds   int
+	}{
+		{
+			name:            "valid sosreport",
+			path:            sosreportTestData,
+			wantError:       false,
+			wantPluginCount: 3, // openvswitch, networking, container_log
+			wantTotalCmds:   3, // 2 from openvswitch, 1 from networking, 0 from container_log
+		},
+		{
+			name:      "non-existent path",
+			path:      "testdata/non-existent",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := listPlugins(tt.path)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("listPlugins() expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("listPlugins() unexpected error = %v", err)
+				return
+			}
+
+			if len(result.Plugins) != tt.wantPluginCount {
+				t.Errorf("listPlugins() got %d plugins, want %d", len(result.Plugins), tt.wantPluginCount)
+			}
+
+			if result.TotalCommands != tt.wantTotalCmds {
+				t.Errorf("listPlugins() got %d total commands, want %d", result.TotalCommands, tt.wantTotalCmds)
+			}
+
+			// Verify plugin names
+			pluginNames := make(map[string]bool)
+			for _, p := range result.Plugins {
+				pluginNames[p.Name] = true
+			}
+			expectedPlugins := []string{"openvswitch", "networking", "container_log"}
+			for _, expected := range expectedPlugins {
+				if !pluginNames[expected] {
+					t.Errorf("listPlugins() missing expected plugin %q", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestListCommands(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		pluginName   string
+		wantError    bool
+		errorMsg     string
+		wantCmdCount int
+	}{
+		{
+			name:         "openvswitch plugin",
+			path:         sosreportTestData,
+			pluginName:   "openvswitch",
+			wantError:    false,
+			wantCmdCount: 2,
+		},
+		{
+			name:         "networking plugin",
+			path:         sosreportTestData,
+			pluginName:   "networking",
+			wantError:    false,
+			wantCmdCount: 1,
+		},
+		{
+			name:         "container_log plugin with no commands",
+			path:         sosreportTestData,
+			pluginName:   "container_log",
+			wantError:    false,
+			wantCmdCount: 0,
+		},
+		{
+			name:       "non-existent plugin",
+			path:       sosreportTestData,
+			pluginName: "non-existent",
+			wantError:  true,
+			errorMsg:   "plugin \"non-existent\" not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := listCommands(tt.path, tt.pluginName)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("listCommands() expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("listCommands() unexpected error = %v", err)
+				return
+			}
+
+			if result.Plugin != tt.pluginName {
+				t.Errorf("listCommands() got plugin %q, want %q", result.Plugin, tt.pluginName)
+			}
+
+			if result.CommandCount != tt.wantCmdCount {
+				t.Errorf("listCommands() got %d commands, want %d", result.CommandCount, tt.wantCmdCount)
+			}
+
+			if len(result.Commands) != tt.wantCmdCount {
+				t.Errorf("listCommands() got %d command entries, want %d", len(result.Commands), tt.wantCmdCount)
+			}
+
+			// For plugins with commands, verify structure
+			if tt.wantCmdCount > 0 {
+				for _, cmd := range result.Commands {
+					if cmd.Exec == "" {
+						t.Errorf("listCommands() command has empty Exec field")
+					}
+					if cmd.Filepath == "" {
+						t.Errorf("listCommands() command has empty Filepath field")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSearchCommands(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		pattern        string
+		maxResults     int
+		wantError      bool
+		wantMinMatches int
+		wantMaxMatches int
+	}{
+		{
+			name:           "search for ovs commands",
+			path:           sosreportTestData,
+			pattern:        "ovs",
+			maxResults:     100,
+			wantError:      false,
+			wantMinMatches: 2, // At least the 2 ovs commands
+			wantMaxMatches: 100,
+		},
+		{
+			name:           "search for ip command",
+			path:           sosreportTestData,
+			pattern:        "ip.*show",
+			maxResults:     100,
+			wantError:      false,
+			wantMinMatches: 1, // ip addr show
+			wantMaxMatches: 100,
+		},
+		{
+			name:           "search with no matches",
+			path:           sosreportTestData,
+			pattern:        "nonexistent-pattern-xyz",
+			maxResults:     100,
+			wantError:      false,
+			wantMinMatches: 0,
+			wantMaxMatches: 0,
+		},
+		{
+			name:       "invalid regex pattern",
+			path:       sosreportTestData,
+			pattern:    "[invalid(",
+			maxResults: 100,
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := searchCommands(tt.path, tt.pattern, tt.maxResults)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("searchCommands() expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("searchCommands() unexpected error = %v", err)
+				return
+			}
+
+			if result.Total < tt.wantMinMatches {
+				t.Errorf("searchCommands() got %d matches, want at least %d", result.Total, tt.wantMinMatches)
+			}
+
+			if result.Total > tt.wantMaxMatches {
+				t.Errorf("searchCommands() got %d matches, want at most %d", result.Total, tt.wantMaxMatches)
+			}
+
+			if len(result.Matches) != result.Total {
+				t.Errorf("searchCommands() matches slice length %d doesn't match Total %d", len(result.Matches), result.Total)
+			}
+
+			// Verify match structure
+			for _, match := range result.Matches {
+				if match.Plugin == "" {
+					t.Errorf("searchCommands() match has empty Plugin field")
+				}
+				if match.Exec == "" {
+					t.Errorf("searchCommands() match has empty Exec field")
+				}
+				if match.Filepath == "" {
+					t.Errorf("searchCommands() match has empty Filepath field")
+				}
+			}
+		})
+	}
+}

--- a/pkg/sosreport/mcp/logs.go
+++ b/pkg/sosreport/mcp/logs.go
@@ -1,0 +1,94 @@
+package sosreport
+
+import (
+	"compress/gzip"
+	"os"
+	"strings"
+	"path/filepath"
+	"regexp"
+	"fmt"
+	"io"
+)
+
+// searchPodLogs searches pod logs using the manifest to find log files
+func searchPodLogs(sosreportPath, pattern, podFilter string, maxResults int) (string, error) {
+	searchPattern, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid search pattern: %w", err)
+	}
+
+	manifest, err := loadManifest(sosreportPath)
+	if err != nil {
+		return "", err
+	}
+
+	if maxResults <= 0 {
+		maxResults = defaultResultLimit
+	}
+
+	containerLogPlugin, exists := manifest.Components.Report.Plugins["container_log"]
+	if !exists || len(containerLogPlugin.Files) == 0 {
+		return "No pod logs found in sosreport\n", nil
+	}
+
+	var result strings.Builder
+	totalMatches := 0
+
+	for _, f := range containerLogPlugin.Files {
+		for _, logPath := range f.FilesCopied {
+			if podFilter != "" && !strings.Contains(logPath, podFilter) {
+				continue
+			}
+
+			// Remove the prefix if exists
+			logPath = strings.TrimPrefix(logPath, "host/")
+
+			fullPath := filepath.Join(sosreportPath, logPath)
+
+			matches, err := searchInFile(fullPath, searchPattern, maxResults-totalMatches)
+			if err != nil {
+				return "", err
+			}
+
+			if len(matches) > 0 {
+				result.WriteString(fmt.Sprintf("\n=== %s ===\n", logPath))
+				result.WriteString(matches)
+				totalMatches += len(strings.Split(matches, "\n"))
+
+				if totalMatches >= maxResults {
+					result.WriteString(fmt.Sprintf("\n... (search truncated at %d results)\n", maxResults))
+					return result.String(), nil
+				}
+			}
+		}
+	}
+	if totalMatches == 0 {
+		return fmt.Sprintf("No matches found for pattern: %s\n", pattern), nil
+	}
+
+	return result.String(), nil
+}
+
+// searchInFile searches in a file (handles both regular and gzip compressed files)
+// Returns the matches and an error
+func searchInFile(filePath string, pattern *regexp.Regexp, maxLines int) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	// Check if file is gzipped
+	var reader io.Reader = file
+	if strings.HasSuffix(filePath, ".gz") {
+		gzReader, err := gzip.NewReader(file)
+		if err != nil {
+			return "", fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	}
+
+	// Read with limit directly from the reader
+	return readWithLimit(reader, pattern, maxLines)
+}

--- a/pkg/sosreport/mcp/logs_test.go
+++ b/pkg/sosreport/mcp/logs_test.go
@@ -1,0 +1,130 @@
+package sosreport
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSearchPodLogs(t *testing.T) {
+	tests := []struct {
+		name           string
+		sosreport      string
+		pattern        string
+		podFilter      string
+		maxResults     int
+		wantError      bool
+		errorMsg       string
+		wantContains   string
+		wantMinMatches int
+		wantMaxMatches int
+	}{
+		{
+			name:           "search for ERROR in logs",
+			sosreport:      sosreportTestData,
+			pattern:        "ERROR",
+			podFilter:      "",
+			maxResults:     100,
+			wantError:      false,
+			wantContains:   "ERROR: Failed to connect",
+			wantMinMatches: 1,
+		},
+		{
+			name:           "filter by pod name",
+			sosreport:      sosreportTestData,
+			pattern:        ".*",
+			podFilter:      "ovnkube-node",
+			maxResults:     100,
+			wantError:      false,
+			wantContains:   "ovnkube-node",
+			wantMinMatches: 1,
+		},
+		{
+			name:           "filter by pod with no match",
+			sosreport:      sosreportTestData,
+			pattern:        ".*",
+			podFilter:      "non-existent-pod",
+			maxResults:     100,
+			wantError:      false,
+			wantContains:   "No matches found",
+			wantMinMatches: 0,
+		},
+		{
+			name:           "search pattern with no matches",
+			sosreport:      sosreportTestData,
+			pattern:        "NOTFOUND",
+			podFilter:      "",
+			maxResults:     100,
+			wantError:      false,
+			wantContains:   "No matches found",
+			wantMinMatches: 0,
+		},
+		{
+			name:           "limit max results",
+			sosreport:      sosreportTestData,
+			pattern:        ".*",
+			podFilter:      "",
+			maxResults:     2,
+			wantError:      false,
+			wantContains:   "search truncated",
+			wantMinMatches: 1,
+			wantMaxMatches: 2,
+		},
+		{
+			name:       "invalid regex pattern",
+			sosreport:  sosreportTestData,
+			pattern:    "[invalid(",
+			podFilter:  "",
+			maxResults: 100,
+			wantError:  true,
+			errorMsg:   "invalid search pattern",
+		},
+		{
+			name:       "invalid sosreport path",
+			sosreport:  "testdata/non-existent",
+			pattern:    "ERROR",
+			podFilter:  "",
+			maxResults: 100,
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := searchPodLogs(tt.sosreport, tt.pattern, tt.podFilter, tt.maxResults)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("searchPodLogs() expected error but got nil")
+				} else if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("searchPodLogs() error = %v, want error containing %q", err, tt.errorMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("searchPodLogs() unexpected error = %v", err)
+				return
+			}
+
+			// Check for expected content
+			if tt.wantContains != "" && !strings.Contains(result, tt.wantContains) {
+				t.Errorf("searchPodLogs() result does not contain %q, got:\n%s", tt.wantContains, result)
+			}
+
+			// For cases with no matches, we should get the "No matches found" message
+			if tt.wantMinMatches == 0 && !strings.Contains(result, "No matches found") {
+				t.Errorf("searchPodLogs() expected 'No matches found' message but didn't get it, got:\n%s", result)
+			}
+
+			// For cases with matches, we shouldn't have the "No matches found" message
+			if tt.wantMinMatches > 0 && strings.Contains(result, "No matches found") {
+				t.Errorf("searchPodLogs() unexpected 'No matches found' message when matches were expected")
+			}
+
+			// Check for truncation message when max results is set
+			if tt.maxResults > 0 && tt.wantMaxMatches > 0 && tt.wantMinMatches > 0 {
+				if !strings.Contains(result, "search truncated") && len(strings.Split(result, "\n")) > tt.maxResults {
+					t.Errorf("searchPodLogs() expected truncation message when max results exceeded")
+				}
+			}
+		})
+	}
+}

--- a/pkg/sosreport/mcp/manifest.go
+++ b/pkg/sosreport/mcp/manifest.go
@@ -1,0 +1,26 @@
+package sosreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/types"
+)
+
+// loadManifest loads and parses the manifest.json file
+func loadManifest(sosreportPath string) (*types.Manifest, error) {
+	manifestPath := filepath.Join(sosreportPath, "sos_reports", "manifest.json")
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest.json: %w", err)
+	}
+
+	var manifest types.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse manifest.json: %w", err)
+	}
+
+	return &manifest, nil
+}

--- a/pkg/sosreport/mcp/manifest_test.go
+++ b/pkg/sosreport/mcp/manifest_test.go
@@ -1,0 +1,50 @@
+package sosreport
+
+import (
+	"testing"
+)
+
+func TestLoadManifest(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name:      "valid manifest",
+			path:      sosreportTestData,
+			wantError: false,
+		},
+		{
+			name:      "non-existent path",
+			path:      "testdata/non-existent",
+			wantError: true,
+			errorMsg:  "failed to read manifest.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := loadManifest(tt.path)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("loadManifest() expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("loadManifest() unexpected error = %v", err)
+					return
+				}
+				if manifest == nil {
+					t.Errorf("loadManifest() returned nil manifest")
+					return
+				}
+				// Verify the manifest has expected structure
+				if manifest.Components.Report.Plugins == nil {
+					t.Errorf("loadManifest() manifest.Components.Report.Plugins is nil")
+				}
+			}
+		})
+	}
+}

--- a/pkg/sosreport/mcp/mcp.go
+++ b/pkg/sosreport/mcp/mcp.go
@@ -1,0 +1,168 @@
+package sosreport
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/types"
+)
+
+// MCPServer provides sosreport analysis tools
+type MCPServer struct{}
+
+// NewMCPServer creates a new sosreport MCP server
+func NewMCPServer() *MCPServer {
+	return &MCPServer{}
+}
+
+// AddTools registers sosreport tools with the MCP server
+func (s *MCPServer) AddTools(server *mcp.Server) {
+	// List enabled plugins
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "sos-list-plugins",
+			Description: `List enabled sosreport plugins with their command counts.
+Parameters:
+- sosreport_path (required): Path to extracted sosreport directory
+
+Returns a list of  plugins with the number of commands collected by each plugin.
+
+Use this to discover which plugins are available, then use sos-list-commands to see
+what commands are available within a specific plugin.
+
+Example output:
+{
+  "plugins": [
+    {"name": "crio", "command_count": 15},
+    {"name": "openvswitch", "command_count": 187},
+    {"name": "networkmanager", "command_count": 2}
+  ],
+  "total_commands": 204
+}`,
+		}, s.ListPlugins)
+
+	// List commands for a plugin
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "sos-list-commands",
+			Description: `List all commands collected by a specific sosreport plugin.
+
+Parameters:
+- sosreport_path (required): Path to extracted sosreport directory
+- plugin (required): Plugin name (e.g. 'openvswitch', 'networking', 'kubernetes')
+
+Returns all commands executed by the plugin with their filepaths. Use the filepath
+with sos-get-command to retrieve the actual command output.
+
+Example:
+- plugin='openvswitch' returns ovs-vsctl, ovs-ofctl, ovs-appctl commands
+- plugin='networking' returns ip, ethtool, netstat commands`,
+		}, s.ListCommands)
+
+	// Search for commands
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "sos-search-commands",
+			Description: fmt.Sprintf(`Search for commands across all plugins by pattern.
+
+Parameters:
+- sosreport_path (required): Path to extracted sosreport directory
+- pattern (required): Regex pattern to search in command exec and filepath
+- max_results (optional): Maximum results to return (default: %d)
+
+Searches command names and filepaths across all plugins. Returns matching commands
+with their plugin, exec string, and filepath. Does NOT return file contents.
+
+Examples:
+- pattern='iptables' finds all iptables-related commands
+- pattern='ovn.*show' finds OVN show commands
+- pattern='journalctl.*kubelet' finds kubelet journal logs`, defaultResultLimit),
+		}, s.SearchCommands)
+
+	// Get command output
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "sos-get-command",
+			Description: fmt.Sprintf(`Get command output using filepath from manifest.
+
+Parameters:
+- sosreport_path (required): Path to extracted sosreport directory
+- filepath (required): Relative filepath from sos-list-commands or sos-search-commands
+- pattern (optional): Regex pattern to filter output lines
+- max_lines (optional): Maximum lines to return (default: %d)
+
+Use the filepath returned by sos-list-commands or sos-search-commands to retrieve
+the actual command output. Supports optional grep-style filtering.
+
+Example:
+- filepath='sos_commands/openvswitch/ovs-vsctl_-t_5_show'
+- filepath='sos_commands/firewall_tables/iptables_-vnxL', pattern='KUBE-'`, defaultResultLimit),
+		}, s.GetCommand)
+
+	// Search pod logs
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "sos-search-pod-logs",
+			Description: fmt.Sprintf(`Search Kubernetes pod container logs.
+
+Parameters:
+- sosreport_path (required): Path to extracted sosreport directory
+- pattern (required): Regex pattern to search for in logs
+- pod_filter (optional): Filter to specific pod/namespace substring
+- max_results (optional): Maximum result lines to return (default: %d)
+
+Searches container logs collected from /var/log/pods/. Returns matching log lines
+with the log file path.
+
+Examples:
+- pattern='ERROR.*', pod_filter='ovnkube-node'
+- pattern='timeout|timed out', pod_filter='ovn'
+- pattern='failed to start'`, defaultResultLimit),
+		}, s.SearchPodLogs)
+}
+
+// ListPlugins lists plugins with command counts
+func (s *MCPServer) ListPlugins(ctx context.Context, req *mcp.CallToolRequest, in types.ListPluginsParams) (*mcp.CallToolResult, types.ListPluginsResult, error) {
+	result, err := listPlugins(in.SosreportPath)
+	if err != nil {
+		return nil, types.ListPluginsResult{}, err
+	}
+	return nil, result, nil
+}
+
+// ListCommands lists all commands for a specific plugin
+func (s *MCPServer) ListCommands(ctx context.Context, req *mcp.CallToolRequest, in types.ListCommandsParams) (*mcp.CallToolResult, types.ListCommandsResult, error) {
+	result, err := listCommands(in.SosreportPath, in.Plugin)
+	if err != nil {
+		return nil, types.ListCommandsResult{}, err
+	}
+	return nil, result, nil
+}
+
+// SearchCommands searches for commands across all plugins
+func (s *MCPServer) SearchCommands(ctx context.Context, req *mcp.CallToolRequest, in types.SearchCommandsParams) (*mcp.CallToolResult, types.SearchCommandsResult, error) {
+	result, err := searchCommands(in.SosreportPath, in.Pattern, in.MaxResults)
+	if err != nil {
+		return nil, types.SearchCommandsResult{}, err
+	}
+	return nil, result, nil
+}
+
+// GetCommand retrieves command output by filepath
+func (s *MCPServer) GetCommand(ctx context.Context, req *mcp.CallToolRequest, in types.GetCommandParams) (*mcp.CallToolResult, types.GetCommandResult, error) {
+	output, err := getCommandOutput(in.SosreportPath, in.Filepath, in.Pattern, in.MaxLines)
+	if err != nil {
+		return nil, types.GetCommandResult{}, err
+	}
+	return nil, types.GetCommandResult{Output: output}, nil
+}
+
+// SearchPodLogs searches pod logs using the manifest
+func (s *MCPServer) SearchPodLogs(ctx context.Context, req *mcp.CallToolRequest, in types.SearchPodLogsParams) (*mcp.CallToolResult, types.SearchPodLogsResult, error) {
+	output, err := searchPodLogs(in.SosreportPath, in.Pattern, in.PodFilter, in.MaxResults)
+	if err != nil {
+		return nil, types.SearchPodLogsResult{}, err
+	}
+	return nil, types.SearchPodLogsResult{Output: output}, nil
+}

--- a/pkg/sosreport/mcp/testdata/sosreport/sos_commands/networking/ip_addr_show
+++ b/pkg/sosreport/mcp/testdata/sosreport/sos_commands/networking/ip_addr_show
@@ -1,0 +1,8 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
+    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.1.100/24 brd 192.168.1.255 scope global eth0
+       valid_lft forever preferred_lft forever

--- a/pkg/sosreport/mcp/testdata/sosreport/sos_commands/openvswitch/ovs-ofctl_dump-flows_br-int
+++ b/pkg/sosreport/mcp/testdata/sosreport/sos_commands/openvswitch/ovs-ofctl_dump-flows_br-int
@@ -1,0 +1,2 @@
+cookie=0x0, duration=1234.567s, table=0, n_packets=100, n_bytes=10000, priority=100,in_port=1 actions=output:2
+cookie=0x0, duration=1234.567s, table=0, n_packets=200, n_bytes=20000, priority=100,in_port=2 actions=output:1

--- a/pkg/sosreport/mcp/testdata/sosreport/sos_commands/openvswitch/ovs-vsctl_-t_5_show
+++ b/pkg/sosreport/mcp/testdata/sosreport/sos_commands/openvswitch/ovs-vsctl_-t_5_show
@@ -1,0 +1,8 @@
+Bridge br-int
+    Port br-int
+        Interface br-int
+            type: internal
+    Port ovn-k8s-mp0
+        Interface ovn-k8s-mp0
+            type: internal
+ovs_version: "2.17.0"

--- a/pkg/sosreport/mcp/testdata/sosreport/sos_reports/manifest.json
+++ b/pkg/sosreport/mcp/testdata/sosreport/sos_reports/manifest.json
@@ -1,0 +1,41 @@
+{
+  "components": {
+    "report": {
+      "plugins": {
+        "openvswitch": {
+          "commands": [
+            {
+              "exec": "ovs-vsctl -t 5 show",
+              "filepath": "sos_commands/openvswitch/ovs-vsctl_-t_5_show",
+              "return_code": 0
+            },
+            {
+              "exec": "ovs-ofctl dump-flows br-int",
+              "filepath": "sos_commands/openvswitch/ovs-ofctl_dump-flows_br-int",
+              "return_code": 0
+            }
+          ]
+        },
+        "networking": {
+          "commands": [
+            {
+              "exec": "ip addr show",
+              "filepath": "sos_commands/networking/ip_addr_show",
+              "return_code": 0
+            }
+          ]
+        },
+        "container_log": {
+          "commands": [],
+          "files": [
+            {
+              "files_copied": [
+                "host/var/log/pods/openshift-ovn-kubernetes_ovnkube-node-abc/ovnkube-node/0.log"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/pkg/sosreport/mcp/testdata/sosreport/var/log/pods/openshift-ovn-kubernetes_ovnkube-node-abc/ovnkube-node/0.log
+++ b/pkg/sosreport/mcp/testdata/sosreport/var/log/pods/openshift-ovn-kubernetes_ovnkube-node-abc/ovnkube-node/0.log
@@ -1,0 +1,5 @@
+2025-10-29T10:00:00.123456789Z stdout F I1029 10:00:00.123456       1 ovnkube.go:123] Starting ovnkube-node
+2025-10-29T10:00:01.234567890Z stdout F I1029 10:00:01.234567       1 ovnkube.go:456] Initialized OVN connection
+2025-10-29T10:00:02.345678901Z stderr F E1029 10:00:02.345678       1 ovnkube.go:789] ERROR: Failed to connect to ovn-controller
+2025-10-29T10:00:03.456789012Z stdout F I1029 10:00:03.456789       1 ovnkube.go:890] Retrying connection
+2025-10-29T10:00:04.567890123Z stdout F I1029 10:00:04.567890       1 ovnkube.go:901] Successfully connected to ovn-controller

--- a/pkg/sosreport/mcp/utils.go
+++ b/pkg/sosreport/mcp/utils.go
@@ -1,0 +1,74 @@
+package sosreport
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"regexp"
+	"bufio"
+	"errors"
+)
+
+// validateSosreportPath validates that the path looks like a sosreport directory
+func validateSosreportPath(sosreportPath string) error {
+	if _, err := os.Stat(sosreportPath); os.IsNotExist(err) {
+		return fmt.Errorf("sosreport path does not exist: %s", sosreportPath)
+	}
+
+	sosCommandsPath := filepath.Join(sosreportPath, "sos_commands")
+	if _, err := os.Stat(sosCommandsPath); os.IsNotExist(err) {
+		return fmt.Errorf("not a valid sosreport: missing sos_commands directory")
+	}
+
+	manifestPath := filepath.Join(sosreportPath, "sos_reports", "manifest.json")
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		return fmt.Errorf("not a valid sosreport: missing sos_reports/manifest.json")
+	}
+
+	return nil
+}
+
+// validateRelativePath validates that a relative path doesn't attempt directory traversal
+func validateRelativePath(relPath string) error {
+	cleanPath := filepath.Clean(relPath)
+
+	if strings.Contains(cleanPath, "..") || filepath.IsAbs(cleanPath) {
+		return errors.New("invalid path: path traversal not allowed")
+	}
+	return nil
+}
+
+// readWithLimit reads from a reader with a line limit
+func readWithLimit(reader io.Reader, pattern *regexp.Regexp, maxLines int) (string, error) {
+	var result strings.Builder
+	scanner := bufio.NewScanner(reader)
+
+	// Increase buffer size for long lines
+	// the size of initial allocation for buffer 4k
+	buf := make([]byte, 4*1024)
+	// the maximum size - 1M
+	scanner.Buffer(buf, 1024*1024)
+
+	lineCount := 0
+	for scanner.Scan() {
+		if pattern == nil || pattern.MatchString(scanner.Text()) {
+			result.WriteString(scanner.Text())
+			result.WriteString("\n")
+			lineCount++
+		}
+
+		if maxLines > 0 && lineCount >= maxLines {
+			result.WriteString(fmt.Sprintf("\n... (output truncated at %d lines)\n", maxLines))
+			break
+		}
+
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return result.String(), nil
+}

--- a/pkg/sosreport/mcp/utils_test.go
+++ b/pkg/sosreport/mcp/utils_test.go
@@ -1,0 +1,188 @@
+package sosreport
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestReadWithLimit(t *testing.T) {
+	// Create a temporary test file
+	tmpfile, err := os.CreateTemp("", "test-readwithlimit-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	// Write test content
+	testContent := `line 1: ERROR occurred
+line 2: INFO message
+line 3: ERROR again
+line 4: DEBUG info
+line 5: ERROR third time
+line 6: WARN warning
+line 7: ERROR fourth
+line 8: INFO another
+line 9: ERROR fifth
+line 10: DEBUG more
+`
+	if _, err := tmpfile.Write([]byte(testContent)); err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+
+	tests := []struct {
+		name        string
+		pattern     string
+		maxLines    int
+		wantLines   int
+		wantPattern string
+		wantTrunc   bool
+	}{
+		{
+			name:      "no pattern, no limit",
+			pattern:   "",
+			maxLines:  0,
+			wantLines: 10,
+			wantTrunc: false,
+		},
+		{
+			name:      "no pattern, with limit",
+			pattern:   "",
+			maxLines:  5,
+			wantLines: 5,
+			wantTrunc: true,
+		},
+		{
+			name:        "with pattern, no limit",
+			pattern:     "ERROR",
+			maxLines:    0,
+			wantLines:   5,
+			wantPattern: "ERROR",
+			wantTrunc:   false,
+		},
+		{
+			name:        "with pattern, with limit",
+			pattern:     "ERROR",
+			maxLines:    3,
+			wantLines:   3,
+			wantPattern: "ERROR",
+			wantTrunc:   true,
+		},
+		{
+			name:        "pattern with no matches returns empty",
+			pattern:     "NOTFOUND",
+			maxLines:    0,
+			wantLines:   0,
+			wantPattern: "NOTFOUND",
+			wantTrunc:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := os.Open(tmpfile.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+
+			var searchPattern *regexp.Regexp
+			if tt.pattern != "" {
+				searchPattern = regexp.MustCompile(tt.pattern)
+			}
+
+			result, err := readWithLimit(file, searchPattern, tt.maxLines)
+			if err != nil {
+				t.Errorf("readWithLimit() unexpected error = %v", err)
+				return
+			}
+
+			// Count lines (excluding truncation message and empty lines)
+			lines := strings.Split(result, "\n")
+			actualLines := 0
+			for _, line := range lines {
+				if line != "" && !strings.Contains(line, "output truncated") && !strings.HasPrefix(line, "...") {
+					actualLines++
+				}
+			}
+
+			// If wantLines is 0, we expect empty string
+			if tt.wantLines == 0 && result != "" {
+				t.Errorf("readWithLimit() expected empty result but got %q", result)
+				return
+			}
+
+			if tt.wantLines > 0 && actualLines != tt.wantLines {
+				t.Errorf("readWithLimit() got %d lines, want %d lines. Result:\n%s", actualLines, tt.wantLines, result)
+			}
+
+			// Check if all lines match the pattern (if pattern is specified)
+			if tt.wantPattern != "" && tt.wantLines > 0 {
+				for _, line := range lines {
+					if line != "" && !strings.Contains(line, "output truncated") && !strings.Contains(line, tt.wantPattern) {
+						t.Errorf("readWithLimit() line %q does not contain pattern %q", line, tt.wantPattern)
+					}
+				}
+			}
+
+			// Check for truncation message
+			hasTruncMsg := strings.Contains(result, "output truncated")
+			if tt.wantTrunc && !hasTruncMsg {
+				t.Errorf("readWithLimit() expected truncation message but didn't find it")
+			}
+			if !tt.wantTrunc && hasTruncMsg {
+				t.Errorf("readWithLimit() unexpected truncation message")
+			}
+		})
+	}
+}
+
+func TestValidateRelativePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "valid simple path",
+			path:    "sos_commands/openvswitch/ovs-vsctl_-t_5_show",
+			wantErr: false,
+		},
+		{
+			name:    "valid nested path",
+			path:    "var/log/pods/namespace_pod/container/0.log",
+			wantErr: false,
+		},
+		{
+			name:    "invalid traversal with ..",
+			path:    "../../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "invalid traversal in middle",
+			path:    "sos_commands/../../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "invalid absolute path",
+			path:    "/etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "valid path with . current dir",
+			path:    "./sos_commands/openvswitch/ovs-vsctl_-t_5_show",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRelativePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRelativePath() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/sosreport/types/command.go
+++ b/pkg/sosreport/types/command.go
@@ -1,0 +1,70 @@
+package types
+
+// ListCommandsParams are the parameters for sos-list-commands
+type ListCommandsParams struct {
+	SosreportPath string `json:"sosreport_path"`
+	Plugin        string `json:"plugin"`
+}
+
+// ListCommandsResult returns commands for a specific plugin
+type ListCommandsResult struct {
+	Plugin       string           `json:"plugin"`
+	CommandCount int              `json:"command_count"`
+	Commands     []CommandSummary `json:"commands"`
+}
+
+// CommandSummary provides a summary of a command
+type CommandSummary struct {
+	Exec     string `json:"exec"`
+	Filepath string `json:"filepath"`
+}
+
+// SearchCommandsParams are the parameters for sos-search-commands
+type SearchCommandsParams struct {
+	SosreportPath string `json:"sosreport_path"`
+	Pattern       string `json:"pattern"`
+	MaxResults    int    `json:"max_results,omitempty"`
+}
+
+// SearchCommandsResult returns commands matching the pattern
+type SearchCommandsResult struct {
+	Matches []CommandMatch `json:"matches"`
+	Total   int            `json:"total"`
+}
+
+// CommandMatch represents a command that matches the search
+type CommandMatch struct {
+	Plugin   string `json:"plugin"`
+	Exec     string `json:"exec"`
+	Filepath string `json:"filepath"`
+}
+
+// GetCommandParams are the parameters for sos-get-command
+type GetCommandParams struct {
+	SosreportPath string `json:"sosreport_path"`
+	Filepath      string `json:"filepath"`
+	Pattern       string `json:"pattern,omitempty"`
+	MaxLines      int    `json:"max_lines,omitempty"`
+}
+
+// GetCommandResult returns the command output
+type GetCommandResult struct {
+	Output string `json:"output"`
+}
+
+// ListPluginsResult returns plugins with command counts
+type ListPluginsResult struct {
+	Plugins       []PluginSummary `json:"plugins"`
+	TotalCommands int             `json:"total_commands"`
+}
+
+// ListPluginsParams are the parameters for sos-list-plugins
+type ListPluginsParams struct {
+	SosreportPath string `json:"sosreport_path"`
+}
+
+// PluginSummary provides a summary of a plugin
+type PluginSummary struct {
+	Name         string `json:"name"`
+	CommandCount int    `json:"command_count"`
+}

--- a/pkg/sosreport/types/logs.go
+++ b/pkg/sosreport/types/logs.go
@@ -1,0 +1,14 @@
+package types
+
+// SearchPodLogsParams are the parameters for sos-search-pod-logs
+type SearchPodLogsParams struct {
+	SosreportPath string `json:"sosreport_path"`
+	Pattern       string `json:"pattern"`
+	PodFilter     string `json:"pod_filter,omitempty"`
+	MaxResults    int    `json:"max_results,omitempty"`
+}
+
+// SearchPodLogsResult returns matching pod log lines
+type SearchPodLogsResult struct {
+	Output string `json:"output"`
+}

--- a/pkg/sosreport/types/manifest.go
+++ b/pkg/sosreport/types/manifest.go
@@ -1,0 +1,53 @@
+package types
+
+// Manifest represents the sosreport manifest.json structure
+type Manifest struct {
+	Version    string     `json:"version"`
+	Cmdline    string     `json:"cmdline"`
+	StartTime  string     `json:"start_time"`
+	EndTime    string     `json:"end_time"`
+	RunTime    string     `json:"run_time"`
+	Components Components `json:"components"`
+}
+
+// Components contains the report components
+type Components struct {
+	Report Report `json:"report"`
+}
+
+// Report contains the sosreport details
+type Report struct {
+	Plugins map[string]PluginDetail `json:"plugins"`
+}
+
+// PluginDetail contains details about a plugin
+type PluginDetail struct {
+	StartTime   string          `json:"start_time"`
+	EndTime     string          `json:"end_time"`
+	RunTime     string          `json:"run_time"`
+	Commands    []CommandDetail `json:"commands"`
+	Files       []FilesDetail   `json:"files"`
+	Containers  interface{}     `json:"containers"`
+	Collections interface{}     `json:"collections"`
+}
+
+// CommandDetail contains details about a command execution
+type CommandDetail struct {
+	Command    string   `json:"command"`
+	Parameters []string `json:"parameters"`
+	Exec       string   `json:"exec"`
+	Filepath   string   `json:"filepath"`
+	Truncated  bool     `json:"truncated"`
+	ReturnCode int      `json:"return_code"`
+	Priority   int      `json:"priority"`
+	StartTime  float64  `json:"start_time"`
+	EndTime    float64  `json:"end_time"`
+	RunTime    float64  `json:"run_time"`
+	Tags       []string `json:"tags"`
+}
+
+// FilesDetail contains details about files collected
+type FilesDetail struct {
+	FilesCopied []string `json:"files_copied"`
+	Tags        []string `json:"tags"`
+}


### PR DESCRIPTION
Implements MCP tools for analyzing [sosreports](https://github.com/sosreport/sos):
  - sos-list-plugins: Lists enabled sosreport plugins with their command counts
  - sos-list-commands: Returns all commands executed by a specific plugin
  - sos-search-commands: Searches for commands matching a pattern across all plugins
  - sos-get-command: Retrieves command output from sosreport with optional regex filtering
  - sos-search-pod-logs: Searches Kubernetes pod container logs with pattern matching

Assisted-By: Claude Sonnet 4.5
Signed-off-by: Patryk Diak <pdiak@redhat.com>



Example using claude code when asked about ovs drops:
```
...
● ovn-kubernetes - sos-get-command (MCP)(sosreport_path: "sosreport-ip-10-0-1-69-2025-10-29-mvjmpmc", filepath: "sos_commands/openvswitch/ovs-ofctl_dump-flows_br-ex", grep_pattern: "drop", max_lines: 200)
  ⎿ {                                                                                                                                                                                                                                                                                                                                                                                                                             
      "output": " cookie=0x304, duration=303.023s, table=0, n_packets=0, n_bytes=0, idle_age=303, priority=700,icmp,in_port=2,nw_dst=172.20.0.1,icmp_type=3,icmp_code=4 actions=drop\n cookie=0x304, duration=303.023s, table=0, n_packets=0, n_bytes=0, idle_age=303, priority=700,icmp,in_port=2,nw_dst=10.0.1.39,icmp_type=3,icmp_code=4 actions=drop\n cookie=0xdeff105, duration=304.192s, table=0, n_packets=0, n_bytes=0, i
    dle_age=304, priority=115,ip,in_port=2,nw_dst=172.30.0.0/16 actions=drop\n cookie=0xdeff105, duration=304.191s, table=0, n_packets=0, n_bytes=0, idle_age=304, priority=103,ip,in_port=2,nw_src=10.128.0.0/14 actions=drop\n cookie=0xdeff105, duration=304.190s, table=0, n_packets=0, n_bytes=0, idle_age=304, priority=9,in_port=2 actions=drop\n"
    }


● Yes, there are several drop flows with traffic hitting them:

  br-int (Integration Bridge):

  Most significant drops:
  - Table 43: 747 packets dropped (1,495,492 bytes) - default drop for unmatched traffic
  - Table 44: 288 packets dropped (786,822 bytes) - IP traffic from 02:95:90:03:29:85 (10.0.1.39)
  - Table 44: 250 packets dropped (34,637 bytes) - hairpin traffic (metadata=0x2, same source/dest)
  - Table 9: 193 packets dropped (15,186 bytes) - traffic marked for drop (reg0=0x8000, metadata=0x1)
  - Table 0: 2 packets dropped (176 bytes) - default drop for unmatched incoming traffic

  Security/anti-spoofing drops (no traffic):
  - ICMP packet-too-big and fragmentation-needed messages
  - Invalid source IPs (0.0.0.0/8, 127.0.0.0/8, 224.0.0.0/4, etc.)
  - TTL=0/1 packets
  - Multicast with wrong TTL
  - Broadcast MAC addresses
  - Router solicitation/advertisement ICMPv6

  br-ex (External Bridge):

  Active drops:
  - Priority 700: ICMP fragmentation needed for 172.20.0.1 and 10.0.1.39
  - Priority 115: Service network traffic (172.30.0.0/16) on port 2
  - Priority 103: Pod network traffic (10.128.0.0/14) on port 2
  - Priority 9: Default drop for port 2

  The largest drop count is in br-int table 43 with nearly 1.5MB of traffic being dropped.

```

Based on https://github.com/ovn-kubernetes/ovn-kubernetes-mcp/pull/1

