### PR TITLE
Add golangci-lint infra for code quality checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Run lint
+      run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
+# podman/docker is installed on the system.
+PODMAN ?= $(shell podman -v > /dev/null 2>&1; echo $$?)
+ifeq ($(PODMAN), 0)
+CONTAINER_RUNTIME?=podman
+else
+CONTAINER_RUNTIME?=docker
+endif
+CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
+
+.PHONY: lint
+lint:
+ifeq ($(CONTAINER_RUNNABLE), 0)
+	@GOPATH=${GOPATH} ./hack/lint.sh $(CONTAINER_RUNTIME) || { echo "lint failed! Try running 'make lint-fix'"; exit 1; }
+else
+	echo "linter can only be run within a container since it needs a specific golangci-lint version"; exit 1
+endif
+
+.PHONY: lint-fix
+lint-fix:
+ifeq ($(CONTAINER_RUNNABLE), 0)
+	@GOPATH=${GOPATH} ./hack/lint.sh $(CONTAINER_RUNTIME) fix || { echo "ERROR: lint fix failed! There is a bug that changes file ownership to root \
+	when this happens. To fix it, simply run 'chown -R <user>:<group> *' from the repo root."; exit 1; }
+else
+	echo "linter can only be run within a container since it needs a specific golangci-lint version"; exit 1
+endif

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+VERSION=v1.64.8
+extra_flags=""
+if [ "$#" -ne 1 ]; then
+  if [ "$#" -eq 2 ] && [ "$2" == "fix" ]; then
+    extra_flags="--fix"
+  else
+    echo "Expected command line argument - container runtime (docker/podman) got $# arguments: $@"
+    exit 1
+  fi
+fi
+
+# Create cache directory if it doesn't exist
+mkdir -p ${HOME}/.cache/golangci-lint
+
+$1 run --security-opt label=disable --rm \
+  -v  ${HOME}/.cache/golangci-lint:/cache -e GOLANGCI_LINT_CACHE=/cache \
+  -v $(pwd):/app -w /app -e GO111MODULE=on docker.io/golangci/golangci-lint:${VERSION} \
+	golangci-lint run --verbose --print-resources-usage \
+	--modules-download-mode=vendor --timeout=15m0s ${extra_flags} && \
+	echo "lint OK!"


### PR DESCRIPTION
## Summary
- Adds Makefile with `lint` and `lint-fix` targets
- Adds `hack/lint.sh` script for containerized linting using golangci-lint v1.64.8
- Adds GitHub Actions workflow to automatically run `make lint` on PRs and pushes to main
- Follows the same approach used in ovn-kubernetes for consistency

## Test plan
- [x] Verified Makefile targets work correctly
- [ ] GitHub Actions workflow will run on this PR to validate the setup

Assisted-by: Claude Code