### PR TITLE
Add MCP Tools for OVS layer

### DIFF
--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -12,6 +12,7 @@ import (
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
+	ovsmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovs/mcp"
 	sosreportmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/mcp"
 )
 
@@ -37,6 +38,9 @@ func main() {
 		}
 		log.Println("Adding Kubernetes tools to OVN-K MCP server")
 		k8sMcpServer.AddTools(ovnkMcpServer)
+		ovsServer := ovsmcp.NewMCPServer(k8sMcpServer)
+		log.Println("Adding OVS tools to OVN-K MCP server")
+		ovsServer.AddTools(ovnkMcpServer)
 	}
 	if serverCfg.Mode == "offline" {
 		sosreportServer := sosreportmcp.NewMCPServer()

--- a/pkg/ovs/mcp/commands.go
+++ b/pkg/ovs/mcp/commands.go
@@ -1,0 +1,126 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+)
+
+const defaultMaxLines = 100
+
+func (s *MCPServer) runCommand(ctx context.Context, req *mcp.CallToolRequest, namespacedName k8stypes.NamespacedNameParams,
+	commands []string) ([]string, error) {
+	_, result, err := s.k8sMcpServer.ExecPod(ctx, req, k8stypes.ExecPodParams{NamespacedNameParams: namespacedName, Command: commands})
+	if err != nil {
+		return nil, err
+	}
+	if result.Stderr != "" {
+		return nil, fmt.Errorf("error occurred while running command %v on pod %s/%s: %s", commands, namespacedName.Namespace,
+			namespacedName.Name, result.Stderr)
+	}
+	output := []string{} // Initialize with empty slice to ensure valid JSON when there's no output
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			output = append(output, line)
+		}
+	}
+	return output, nil
+}
+
+// filterLines filters lines using a regex pattern.
+func filterLines(lines []string, pattern string) ([]string, error) {
+	if pattern == "" {
+		return lines, nil
+	}
+
+	filterPattern, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid filter pattern %s: %w", pattern, err)
+	}
+
+	filtered := []string{} // Initialize with empty slice to ensure valid JSON when there's no output
+	for _, line := range lines {
+		if filterPattern.MatchString(line) {
+			filtered = append(filtered, line)
+		}
+	}
+	return filtered, nil
+}
+
+// limitLines limits the number of lines returned.
+func limitLines(lines []string, maxLines int) []string {
+	if maxLines <= 0 {
+		maxLines = defaultMaxLines
+	}
+	if len(lines) > maxLines {
+		return lines[:maxLines]
+	}
+	return lines
+}
+
+// validateBridgeName validates that a bridge name is safe and non-empty.
+// Bridge names should only contain alphanumeric characters, hyphens, and underscores.
+func validateBridgeName(bridge string) error {
+	if bridge == "" {
+		return fmt.Errorf("bridge name cannot be empty")
+	}
+
+	// OVS bridge names typically follow naming conventions: alphanumeric, hyphens, underscores
+	validBridgeName := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	if !validBridgeName.MatchString(bridge) {
+		return fmt.Errorf("invalid bridge name %q: must contain only alphanumeric characters, hyphens, and underscores", bridge)
+	}
+
+	return nil
+}
+
+// validateFlowSpec validates that a flow specification is safe and non-empty.
+func validateFlowSpec(flow string) error {
+	if flow == "" {
+		return fmt.Errorf("flow specification cannot be empty")
+	}
+
+	// Check for potentially dangerous characters that shouldn't appear in flow specs
+	// Flow specs should contain: alphanumeric, commas, equals, colons, periods, slashes, parentheses, brackets
+	// We explicitly block: semicolons, pipes, backticks, dollar signs, and other shell metacharacters
+	dangerousChars := regexp.MustCompile(`[;&|$` + "`" + `<>\\]`)
+	if dangerousChars.MatchString(flow) {
+		return fmt.Errorf("invalid flow specification: contains potentially dangerous characters")
+	}
+
+	return nil
+}
+
+// validateConntrackParams validates that conntrack additional parameters are safe.
+// Valid parameters for dpctl/dump-conntrack include: zone=N, mark=0xN, labels=0xN, -m, -s, etc.
+func validateConntrackParams(params []string) error {
+	for _, param := range params {
+		if param == "" {
+			return fmt.Errorf("conntrack parameter cannot be empty")
+		}
+
+		// Check for potentially dangerous characters
+		// Valid conntrack params should contain: alphanumeric, equals, hyphens, underscores, periods, colons, commas, forward slashes
+		// We explicitly block: semicolons, pipes, backticks, dollar signs, ampersands, and other shell metacharacters
+		dangerousChars := regexp.MustCompile(`[;&|$` + "`" + `<>\\()]`)
+		if dangerousChars.MatchString(param) {
+			return fmt.Errorf("invalid conntrack parameter %q: contains potentially dangerous characters", param)
+		}
+
+		// Additional validation for common parameter patterns
+		// Valid patterns include:
+		// - Single-char flags: -m, -s (single hyphen followed by single letter)
+		// - Key=value pairs: zone=5, mark=0x1, src=10.0.0.1 (key must contain only alphanumeric, underscore, hyphen)
+		validParam := regexp.MustCompile(`^(-[a-zA-Z]|[a-zA-Z0-9_-]+=[a-zA-Z0-9x.:,/_-]+)$`)
+		if !validParam.MatchString(param) {
+			return fmt.Errorf("invalid conntrack parameter format %q: must be a flag (e.g., '-m') or key=value pair (e.g., 'zone=5')", param)
+		}
+	}
+
+	return nil
+}

--- a/pkg/ovs/mcp/commands_test.go
+++ b/pkg/ovs/mcp/commands_test.go
@@ -1,0 +1,504 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestFilterLines(t *testing.T) {
+	tests := []struct {
+		name    string
+		lines   []string
+		pattern string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "empty pattern returns all lines",
+			lines:   []string{"line1", "line2", "line3"},
+			pattern: "",
+			want:    []string{"line1", "line2", "line3"},
+			wantErr: false,
+		},
+		{
+			name:    "simple string match",
+			lines:   []string{"foo", "bar", "foo bar", "baz"},
+			pattern: "foo",
+			want:    []string{"foo", "foo bar"},
+			wantErr: false,
+		},
+		{
+			name:    "regex pattern match",
+			lines:   []string{"table=0", "table=10", "priority=100", "table=5"},
+			pattern: `table=\d+`,
+			want:    []string{"table=0", "table=10", "table=5"},
+			wantErr: false,
+		},
+		{
+			name:    "no matches returns empty slice",
+			lines:   []string{"line1", "line2", "line3"},
+			pattern: "nomatch",
+			want:    []string{},
+			wantErr: false,
+		},
+		{
+			name:    "invalid regex pattern returns error",
+			lines:   []string{"line1", "line2"},
+			pattern: "[invalid",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty lines with pattern",
+			lines:   []string{},
+			pattern: "test",
+			want:    []string{},
+			wantErr: false,
+		},
+		{
+			name:    "complex regex with multiple groups",
+			lines:   []string{"cookie=0x0, table=0", "cookie=0x1, table=10", "priority=100"},
+			pattern: `cookie=0x[0-9a-f]+`,
+			want:    []string{"cookie=0x0, table=0", "cookie=0x1, table=10"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterLines(tt.lines, tt.pattern)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("filterLines() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(got) != len(tt.want) {
+					t.Errorf("filterLines() got %d lines, want %d lines", len(got), len(tt.want))
+					return
+				}
+				for i := range got {
+					if got[i] != tt.want[i] {
+						t.Errorf("filterLines()[%d] = %v, want %v", i, got[i], tt.want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLimitLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		lines    []string
+		maxLines int
+		want     []string
+	}{
+		{
+			name:     "negative maxLines uses default of 100",
+			lines:    make([]string, 150),
+			maxLines: -1,
+			want:     make([]string, 100),
+		},
+		{
+			name:     "zero maxLines uses default of 100",
+			lines:    make([]string, 150),
+			maxLines: 0,
+			want:     make([]string, 100),
+		},
+		{
+			name:     "zero maxLines with fewer lines returns all",
+			lines:    []string{"line1", "line2", "line3"},
+			maxLines: 0,
+			want:     []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "positive maxLines less than 100 returns limited lines",
+			lines:    make([]string, 150),
+			maxLines: 50,
+			want:     make([]string, 50),
+		},
+		{
+			name:     "maxLines greater than length returns all lines",
+			lines:    []string{"line1", "line2", "line3"},
+			maxLines: 10,
+			want:     []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "maxLines equal to length returns all lines",
+			lines:    []string{"line1", "line2", "line3"},
+			maxLines: 3,
+			want:     []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "maxLines less than length returns limited lines",
+			lines:    []string{"line1", "line2", "line3", "line4", "line5"},
+			maxLines: 2,
+			want:     []string{"line1", "line2"},
+		},
+		{
+			name:     "maxLines 1 returns first line",
+			lines:    []string{"line1", "line2", "line3"},
+			maxLines: 1,
+			want:     []string{"line1"},
+		},
+		{
+			name:     "empty lines with maxLines",
+			lines:    []string{},
+			maxLines: 5,
+			want:     []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := limitLines(tt.lines, tt.maxLines)
+			if len(got) != len(tt.want) {
+				t.Errorf("limitLines() got %d lines, want %d lines", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("limitLines()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateBridgeName(t *testing.T) {
+	tests := []struct {
+		name    string
+		bridge  string
+		wantErr bool
+	}{
+		{
+			name:    "valid bridge name with hyphen",
+			bridge:  "br-int",
+			wantErr: false,
+		},
+		{
+			name:    "valid bridge name with underscore",
+			bridge:  "br_ex",
+			wantErr: false,
+		},
+		{
+			name:    "valid bridge name alphanumeric",
+			bridge:  "br0",
+			wantErr: false,
+		},
+		{
+			name:    "valid bridge name mixed",
+			bridge:  "br-local_123",
+			wantErr: false,
+		},
+		{
+			name:    "empty bridge name returns error",
+			bridge:  "",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with space returns error",
+			bridge:  "br int",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with slash returns error",
+			bridge:  "br/int",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with semicolon returns error",
+			bridge:  "br;int",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with pipe returns error",
+			bridge:  "br|int",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with dollar returns error",
+			bridge:  "br$int",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with backtick returns error",
+			bridge:  "br`int",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with special chars returns error",
+			bridge:  "br@int",
+			wantErr: true,
+		},
+		{
+			name:    "bridge name with parentheses returns error",
+			bridge:  "br(int)",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBridgeName(tt.bridge)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateBridgeName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateFlowSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		flow    string
+		wantErr bool
+	}{
+		{
+			name:    "valid flow with in_port",
+			flow:    "in_port=1,icmp",
+			wantErr: false,
+		},
+		{
+			name:    "valid flow with IP addresses",
+			flow:    "in_port=2,ip,nw_src=192.168.1.10,nw_dst=192.168.1.20",
+			wantErr: false,
+		},
+		{
+			name:    "valid flow with TCP ports",
+			flow:    "in_port=3,tcp,nw_src=10.0.0.1,nw_dst=10.0.0.2,tp_src=12345,tp_dst=80",
+			wantErr: false,
+		},
+		{
+			name:    "valid flow with brackets",
+			flow:    "in_port=1,ip,nw_src=10.244.0.5,nw_dst=10.96.0.1",
+			wantErr: false,
+		},
+		{
+			name:    "valid flow with parentheses",
+			flow:    "flow(test)",
+			wantErr: false,
+		},
+		{
+			name:    "valid flow with forward slash",
+			flow:    "in_port=1,ip,nw_src=10.0.0.0/24",
+			wantErr: false,
+		},
+		{
+			name:    "empty flow returns error",
+			flow:    "",
+			wantErr: true,
+		},
+		{
+			name:    "flow with semicolon returns error",
+			flow:    "in_port=1;icmp",
+			wantErr: true,
+		},
+		{
+			name:    "flow with ampersand returns error",
+			flow:    "in_port=1&icmp",
+			wantErr: true,
+		},
+		{
+			name:    "flow with pipe returns error",
+			flow:    "in_port=1|icmp",
+			wantErr: true,
+		},
+		{
+			name:    "flow with dollar returns error",
+			flow:    "in_port=$1,icmp",
+			wantErr: true,
+		},
+		{
+			name:    "flow with backtick returns error",
+			flow:    "in_port=`1`,icmp",
+			wantErr: true,
+		},
+		{
+			name:    "flow with less than returns error",
+			flow:    "in_port=1,icmp<test",
+			wantErr: true,
+		},
+		{
+			name:    "flow with greater than returns error",
+			flow:    "in_port=1,icmp>test",
+			wantErr: true,
+		},
+		{
+			name:    "flow with backslash returns error",
+			flow:    "in_port=1\\icmp",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFlowSpec(tt.flow)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateFlowSpec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateConntrackParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  []string
+		wantErr bool
+	}{
+		{
+			name:    "empty params array is valid",
+			params:  []string{},
+			wantErr: false,
+		},
+		{
+			name:    "valid zone parameter",
+			params:  []string{"zone=5"},
+			wantErr: false,
+		},
+		{
+			name:    "valid mark parameter with hex",
+			params:  []string{"mark=0x1"},
+			wantErr: false,
+		},
+		{
+			name:    "valid labels parameter with hex",
+			params:  []string{"labels=0xabcd1234"},
+			wantErr: false,
+		},
+		{
+			name:    "valid flag parameter",
+			params:  []string{"-m"},
+			wantErr: false,
+		},
+		{
+			name:    "valid multiple flags",
+			params:  []string{"-m", "-s"},
+			wantErr: false,
+		},
+		{
+			name:    "valid src parameter with IP",
+			params:  []string{"src=10.244.0.5"},
+			wantErr: false,
+		},
+		{
+			name:    "valid dst parameter with IP",
+			params:  []string{"dst=192.168.1.1"},
+			wantErr: false,
+		},
+		{
+			name:    "valid multiple parameters",
+			params:  []string{"zone=5", "mark=0x1", "-m"},
+			wantErr: false,
+		},
+		{
+			name:    "valid parameter with colon",
+			params:  []string{"src=10.0.0.1:8080"},
+			wantErr: false,
+		},
+		{
+			name:    "valid parameter with comma",
+			params:  []string{"zone=1,2"},
+			wantErr: false,
+		},
+		{
+			name:    "valid parameter with forward slash",
+			params:  []string{"src=10.0.0.0/24"},
+			wantErr: false,
+		},
+		{
+			name:    "valid parameter with underscore",
+			params:  []string{"ct_zone=5"},
+			wantErr: false,
+		},
+		{
+			name:    "valid parameter with hyphen in name",
+			params:  []string{"ct-zone=5"},
+			wantErr: false,
+		},
+		{
+			name:    "empty string parameter returns error",
+			params:  []string{""},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with semicolon returns error",
+			params:  []string{"zone=5;ls"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with ampersand returns error",
+			params:  []string{"zone=5&ls"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with pipe returns error",
+			params:  []string{"zone=5|ls"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with dollar returns error",
+			params:  []string{"zone=$USER"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with backtick returns error",
+			params:  []string{"zone=`id`"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with less than returns error",
+			params:  []string{"zone=5<test"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with greater than returns error",
+			params:  []string{"zone=5>test"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with backslash returns error",
+			params:  []string{"zone=5\\test"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with opening parenthesis returns error",
+			params:  []string{"zone=(5)"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with closing parenthesis returns error",
+			params:  []string{"zone=5)"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid format without equals or flag returns error",
+			params:  []string{"zonefive"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid flag format returns error",
+			params:  []string{"--zone"},
+			wantErr: true,
+		},
+		{
+			name:    "parameter with space returns error",
+			params:  []string{"zone=5 test"},
+			wantErr: true,
+		},
+		{
+			name:    "one valid and one invalid parameter returns error",
+			params:  []string{"zone=5", "mark=0x1;ls"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConntrackParams(tt.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateConntrackParams() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/ovs/mcp/mcp.go
+++ b/pkg/ovs/mcp/mcp.go
@@ -1,0 +1,393 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+	ovstypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovs/types"
+)
+
+// MCPServer provides OVS layer analysis tools
+type MCPServer struct {
+	k8sMcpServer *kubernetesmcp.MCPServer
+}
+
+// NewMCPServer creates a new OVS MCP server
+func NewMCPServer(k8sMcpServer *kubernetesmcp.MCPServer) *MCPServer {
+	return &MCPServer{
+		k8sMcpServer: k8sMcpServer,
+	}
+}
+
+// AddTools registers OVS tools with the MCP server
+func (s *MCPServer) AddTools(server *mcp.Server) {
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "ovs-list-br",
+			Description: `List all OVS bridges on a specific pod.
+
+Runs 'ovs-vsctl list-br' command and returns the names of all configured bridges.
+
+Parameters:
+- namespace: Kubernetes namespace of the OVS pod
+- name: Name of the pod running OVS
+
+Example output:
+{
+  "bridges": [
+    "br-int",
+    "br-ex",
+    "br-local"
+  ]
+}`,
+		}, s.ListBridges)
+
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "ovs-list-ports",
+			Description: `List all ports on a specific OVS bridge.
+
+Runs 'ovs-vsctl list-ports' command and returns the names of all ports attached to the specified bridge.
+
+Parameters:
+- namespace: Kubernetes namespace of the OVS pod
+- name: Name of the pod running OVS
+- bridge: Name of the OVS bridge (e.g., "br-int")
+
+Example output:
+{
+  "ports": [
+    "patch-br-int-to-br-ex",
+    "veth1234",
+    "ovn-k8s-mp0"
+  ]
+}`,
+		}, s.ListPorts)
+
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "ovs-list-ifaces",
+			Description: `List all interfaces on a specific OVS bridge.
+
+Runs 'ovs-vsctl list-ifaces' command and returns the names of all interfaces attached to the specified bridge.
+
+Parameters:
+- namespace: Kubernetes namespace of the OVS pod
+- name: Name of the pod running OVS
+- bridge: Name of the OVS bridge (e.g., "br-int")
+
+Example output:
+{
+  "interfaces": [
+    "patch-br-int-to-br-ex",
+    "veth1234",
+    "ovn-k8s-mp0"
+  ]
+}`,
+		}, s.ListInterfaces)
+
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "ovs-vsctl-show",
+			Description: `Display a comprehensive overview of OVS configuration.
+
+Runs 'ovs-vsctl show' command and returns detailed information about bridges, ports, interfaces,
+controllers, and their configurations in a hierarchical format.
+
+This command is useful for getting a complete view of the OVS switch configuration including:
+- All bridges and their configurations
+- Ports and interfaces attached to each bridge
+- Controller connections and status
+- Interface types and options
+- Port configurations and tags
+
+Parameters:
+- namespace: Kubernetes namespace of the OVS pod
+- name: Name of the pod running OVS
+- max_lines (optional): Limit the number of output lines returned
+
+Example output:
+{
+  "output": "a1b2c3d4-5678-90ab-cdef-1234567890ab\n    Bridge br-int\n        Port ovn-k8s-mp0\n            Interface ovn-k8s-mp0\n                type: internal\n        Port br-int\n            Interface br-int\n                type: internal\n    ovs_version: \"2.17.0\""
+}`,
+		}, s.Show)
+
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "ovs-ofctl-dump-flows",
+			Description: `Dump OpenFlow flows from a specific OVS bridge.
+
+Runs 'ovs-ofctl dump-flows' command on the specified bridge and returns the flow entries.
+
+Parameters:
+- namespace: Kubernetes namespace of the OVS pod
+- name: Name of the pod running OVS
+- bridge: Name of the OVS bridge (e.g., "br-int")
+- filter (optional): Regex pattern to filter flows
+- max_lines (optional): Limit the number of flows returned
+
+Example output:
+{
+  "bridge": "br-int",
+  "flows": [
+    "cookie=0x0, duration=123.456s, table=0, n_packets=100, n_bytes=10000, priority=100,in_port=1 actions=output:2",
+    "cookie=0x0, duration=123.456s, table=0, n_packets=50, n_bytes=5000, priority=90,in_port=2 actions=output:1"
+  ]
+}`,
+		}, s.DumpFlows)
+
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "ovs-appctl-dump-conntrack",
+			Description: `Dump connection tracking entries from OVS datapath.
+
+Runs 'ovs-appctl dpctl/dump-conntrack' command and returns the conntrack entries.
+
+Connection tracking (conntrack) maintains state for stateful firewall rules and NAT.
+Each entry shows source/destination IPs, ports, protocol, connection state, and more.
+
+Parameters:
+- namespace: Kubernetes namespace of the OVS pod
+- name: Name of the pod running OVS
+- filter (optional): Regex pattern to filter conntrack entries
+- max_lines (optional): Limit the number of entries returned
+- additional_params (optional): Additional parameters to pass to dpctl/dump-conntrack command (e.g., ["zone=5"])
+
+Example output:
+{
+  "entries": [
+    "tcp,orig=(src=10.244.0.5,dst=10.96.0.1,sport=45678,dport=443),reply=(src=10.96.0.1,dst=10.244.0.5,sport=443,dport=45678)",
+    "udp,orig=(src=10.244.0.3,dst=8.8.8.8,sport=53214,dport=53),reply=(src=8.8.8.8,dst=10.244.0.3,sport=53,dport=53214)"
+  ]
+}`,
+		}, s.DumpConntrack)
+
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "ovs-appctl-ofproto-trace",
+			Description: `Trace a packet through the OpenFlow pipeline.
+
+Runs 'ovs-appctl ofproto/trace' command to simulate packet processing through OpenFlow tables.
+This shows which flows match, what actions are taken, and the final disposition of the packet.
+
+The trace output is essential for debugging flow rules, understanding packet forwarding decisions,
+and troubleshooting connectivity issues.
+
+Parameters:
+- namespace: Kubernetes namespace of the OVS pod
+- name: Name of the pod running OVS
+- bridge: Name of the OVS bridge (e.g., "br-int")
+- flow: Flow specification describing the packet to trace (e.g., "in_port=1,ip,nw_src=10.244.0.5,nw_dst=10.96.0.1")
+- filter (optional): Regex pattern to filter trace output lines
+- max_lines (optional): Limit the number of output lines returned
+
+Flow specification examples:
+- "in_port=1,icmp"
+- "in_port=2,ip,nw_src=192.168.1.10,nw_dst=192.168.1.20"
+- "in_port=3,tcp,nw_src=10.0.0.1,nw_dst=10.0.0.2,tp_src=12345,tp_dst=80"
+
+Example output:
+{
+  "bridge": "br-int",
+  "flow": "in_port=1,ip,nw_src=10.244.0.5,nw_dst=10.96.0.1",
+  "output": "Flow: ip,in_port=1,nw_src=10.244.0.5,nw_dst=10.96.0.1\n\nbridge(\"br-int\")\n-------------\n 0. priority 100\n    resubmit(,10)\n10. ip,nw_dst=10.96.0.1, priority 200\n    load:0x1->NXM_NX_REG0[]\n    resubmit(,20)\n...\nFinal flow: ...\nDatapath actions: ..."
+}`,
+		}, s.DumpOfprotoTrace)
+}
+
+func (s *MCPServer) ListBridges(ctx context.Context, req *mcp.CallToolRequest,
+	in k8stypes.NamespacedNameParams) (*mcp.CallToolResult, ovstypes.BridgeResult, error) {
+	result := ovstypes.BridgeResult{
+		Bridges: []string{}, // Initialize with empty slice to ensure valid JSON even on error
+	}
+
+	// Run ovs-vsctl list-br command
+	bridgeNames, err := s.runCommand(ctx, req, in, []string{"ovs-vsctl", "list-br"})
+	if err != nil {
+		return nil, result, fmt.Errorf("failed to retrieve ovs bridge from pod %s/%s: %w",
+			in.Namespace, in.Name, err)
+	}
+	result.Bridges = append(result.Bridges, bridgeNames...)
+	return nil, result, nil
+}
+
+// Show displays a comprehensive overview of OVS configuration.
+func (s *MCPServer) Show(ctx context.Context, req *mcp.CallToolRequest,
+	in ovstypes.ShowParams) (*mcp.CallToolResult, ovstypes.ShowResult, error) {
+	result := ovstypes.ShowResult{}
+
+	// Run ovs-vsctl show command
+	lines, err := s.runCommand(ctx, req, in.NamespacedNameParams, []string{"ovs-vsctl", "show"})
+	if err != nil {
+		return nil, result, fmt.Errorf("failed to retrieve ovs configuration from pod %s/%s: %w",
+			in.Namespace, in.Name, err)
+	}
+
+	// Limit to MaxLines if specified
+	lines = limitLines(lines, in.MaxLines)
+
+	// Join all lines into a single output string
+	result.Output = strings.Join(lines, "\n")
+	return nil, result, nil
+}
+
+func (s *MCPServer) ListPorts(ctx context.Context, req *mcp.CallToolRequest,
+	in ovstypes.GetOVSCommandParams) (*mcp.CallToolResult, ovstypes.PortResult, error) {
+	result := ovstypes.PortResult{
+		Ports: []string{}, // Initialize with empty slice to ensure valid JSON even on error
+	}
+
+	// Validate bridge name
+	if err := validateBridgeName(in.Bridge); err != nil {
+		return nil, result, err
+	}
+
+	// Run ovs-vsctl list-ports command
+	ports, err := s.runCommand(ctx, req, in.NamespacedNameParams, []string{"ovs-vsctl", "list-ports", in.Bridge})
+	if err != nil {
+		return nil, result, fmt.Errorf("failed to retrieve ports for bridge %s from pod %s/%s: %w",
+			in.Bridge, in.Namespace, in.Name, err)
+	}
+	result.Ports = append(result.Ports, ports...)
+	return nil, result, nil
+}
+
+func (s *MCPServer) ListInterfaces(ctx context.Context, req *mcp.CallToolRequest,
+	in ovstypes.GetOVSCommandParams) (*mcp.CallToolResult, ovstypes.InterfaceResult, error) {
+	result := ovstypes.InterfaceResult{
+		Interfaces: []string{}, // Initialize with empty slice to ensure valid JSON even on error
+	}
+
+	// Validate bridge name
+	if err := validateBridgeName(in.Bridge); err != nil {
+		return nil, result, err
+	}
+
+	// Run ovs-vsctl list-ifaces command
+	ports, err := s.runCommand(ctx, req, in.NamespacedNameParams, []string{"ovs-vsctl", "list-ifaces", in.Bridge})
+	if err != nil {
+		return nil, result, fmt.Errorf("failed to retrieve interfaces for bridge %s from pod %s/%s: %w",
+			in.Bridge, in.Namespace, in.Name, err)
+	}
+	result.Interfaces = append(result.Interfaces, ports...)
+	return nil, result, nil
+}
+
+// DumpFlows dumps flows from a specific OVS bridge.
+func (s *MCPServer) DumpFlows(ctx context.Context, req *mcp.CallToolRequest,
+	in ovstypes.GetOVSCommandParams) (*mcp.CallToolResult, ovstypes.FlowsResult, error) {
+	result := ovstypes.FlowsResult{
+		Bridge: in.Bridge,
+		Flows:  []string{}, // Initialize with empty slice to ensure valid JSON even on error
+	}
+
+	// Validate bridge name
+	if err := validateBridgeName(in.Bridge); err != nil {
+		return nil, result, err
+	}
+
+	// Run ovs-ofctl dump-flows command
+	flows, err := s.runCommand(ctx, req, in.NamespacedNameParams, []string{"ovs-ofctl", "dump-flows", in.Bridge})
+	if err != nil {
+		return nil, result, fmt.Errorf("failed to dump flows for bridge %s on pod %s/%s: %w",
+			in.Bridge, in.NamespacedNameParams.Namespace, in.NamespacedNameParams.Name, err)
+	}
+
+	// Filter flows by pattern if provided
+	flows, err = filterLines(flows, in.Filter)
+	if err != nil {
+		return nil, result, fmt.Errorf("invalid filter pattern: %w", err)
+	}
+
+	// Limit to MaxLines if specified
+	flows = limitLines(flows, in.MaxLines)
+
+	result.Flows = flows
+	return nil, result, nil
+}
+
+// DumpConntrack dumps connection tracking entries from OVS datapath.
+func (s *MCPServer) DumpConntrack(ctx context.Context, req *mcp.CallToolRequest,
+	in ovstypes.DumpConntrackParams) (*mcp.CallToolResult, ovstypes.ConntrackResult, error) {
+	result := ovstypes.ConntrackResult{
+		Entries: []string{}, // Initialize with empty slice to ensure valid JSON even on error
+	}
+
+	// Validate additional parameters if provided
+	if len(in.AdditionalParams) > 0 {
+		if err := validateConntrackParams(in.AdditionalParams); err != nil {
+			return nil, result, err
+		}
+	}
+
+	// Build command with additional parameters
+	cmd := []string{"ovs-appctl", "dpctl/dump-conntrack"}
+	if len(in.AdditionalParams) > 0 {
+		cmd = append(cmd, in.AdditionalParams...)
+	}
+
+	// Run ovs-appctl dpctl/dump-conntrack command
+	entries, err := s.runCommand(ctx, req, in.NamespacedNameParams, cmd)
+	if err != nil {
+		return nil, result, fmt.Errorf("failed to dump conntrack on pod %s/%s: %w",
+			in.NamespacedNameParams.Namespace, in.NamespacedNameParams.Name, err)
+	}
+
+	// Filter entries by pattern if provided
+	entries, err = filterLines(entries, in.Filter)
+	if err != nil {
+		return nil, result, fmt.Errorf("invalid filter pattern: %w", err)
+	}
+
+	// Limit to MaxLines if specified
+	entries = limitLines(entries, in.MaxLines)
+
+	result.Entries = entries
+	return nil, result, nil
+}
+
+// DumpOfprotoTrace traces a packet through the OpenFlow pipeline.
+func (s *MCPServer) DumpOfprotoTrace(ctx context.Context, req *mcp.CallToolRequest,
+	in ovstypes.OfprotoTraceParams) (*mcp.CallToolResult, ovstypes.OfprotoTraceResult, error) {
+	result := ovstypes.OfprotoTraceResult{
+		Bridge: in.Bridge,
+		Flow:   in.Flow,
+	}
+
+	// Validate bridge name
+	if err := validateBridgeName(in.Bridge); err != nil {
+		return nil, result, err
+	}
+
+	// Validate flow specification
+	if err := validateFlowSpec(in.Flow); err != nil {
+		return nil, result, err
+	}
+
+	// Build command: ovs-appctl ofproto/trace <bridge> <flow>
+	cmd := []string{"ovs-appctl", "ofproto/trace", in.Bridge, in.Flow}
+
+	// Run ovs-appctl ofproto/trace command
+	lines, err := s.runCommand(ctx, req, in.NamespacedNameParams, cmd)
+	if err != nil {
+		return nil, result, fmt.Errorf("failed to trace flow on bridge %s, pod %s/%s: %w",
+			in.Bridge, in.NamespacedNameParams.Namespace, in.NamespacedNameParams.Name, err)
+	}
+
+	// Filter lines by pattern if provided
+	lines, err = filterLines(lines, in.Filter)
+	if err != nil {
+		return nil, result, fmt.Errorf("invalid filter pattern: %w", err)
+	}
+
+	// Limit to MaxLines if specified
+	lines = limitLines(lines, in.MaxLines)
+
+	// Join all lines into a single output string
+	result.Output = strings.Join(lines, "\n")
+	return nil, result, nil
+}

--- a/pkg/ovs/types/command.go
+++ b/pkg/ovs/types/command.go
@@ -1,0 +1,74 @@
+package types
+
+import (
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+)
+
+// BridgeResult contains the list of OVS bridges found on a node.
+type BridgeResult struct {
+	Bridges []string `json:"bridges"`
+}
+
+// ShowParams are the parameters for ovs-vsctl show command.
+type ShowParams struct {
+	k8stypes.NamespacedNameParams
+	MaxLines int `json:"max_lines,omitempty"`
+}
+
+// ShowResult contains the output of ovs-vsctl show command.
+type ShowResult struct {
+	Output string `json:"output"`
+}
+
+// PortResult contains the list of ports attached to an OVS bridge.
+type PortResult struct {
+	Ports []string `json:"ports"`
+}
+
+// InterfaceResult contains the list of interfaces attached to an OVS bridge.
+type InterfaceResult struct {
+	Interfaces []string `json:"interfaces"`
+}
+
+// FlowsResult contains the OpenFlow flows from a specific OVS bridge.
+type FlowsResult struct {
+	Flows  []string `json:"flows"`
+	Bridge string   `json:"bridge"`
+}
+
+// ConntrackResult contains connection tracking entries from the OVS datapath.
+type ConntrackResult struct {
+	Entries []string `json:"entries"`
+}
+
+// GetOVSCommandParams are the parameters for OVS related commands.
+type GetOVSCommandParams struct {
+	k8stypes.NamespacedNameParams
+	Bridge   string `json:"bridge"`
+	Filter   string `json:"filter,omitempty"`
+	MaxLines int    `json:"max_lines,omitempty"`
+}
+
+// DumpConntrackParams are the parameters for dump-conntrack command.
+type DumpConntrackParams struct {
+	k8stypes.NamespacedNameParams
+	Filter           string   `json:"filter,omitempty"`
+	MaxLines         int      `json:"max_lines,omitempty"`
+	AdditionalParams []string `json:"additional_params,omitempty"`
+}
+
+// OfprotoTraceParams are the parameters for ofproto/trace command.
+type OfprotoTraceParams struct {
+	k8stypes.NamespacedNameParams
+	Bridge   string `json:"bridge"`
+	Flow     string `json:"flow"`
+	Filter   string `json:"filter,omitempty"`
+	MaxLines int    `json:"max_lines,omitempty"`
+}
+
+// OfprotoTraceResult returns the complete trace output.
+type OfprotoTraceResult struct {
+	Bridge string `json:"bridge"`
+	Flow   string `json:"flow"`
+	Output string `json:"output"`
+}


### PR DESCRIPTION
This PR introduces four new MCP tools for inspecting and debugging OVS in ovn-kubernetes clusters:
    
- ovs-list-br: List all OVS bridges on a pod
- ovs-list-ports: List all ports attached to an OVS bridge
- ovs-list-ifaces: List all interfaces attached to an OVS bridge
- ovs-vsctl-show: Display comprehensive OVS configuration overview
- ovs-ofctl-dump-flows: Dump and analyze OpenFlow rules from OVS bridges
  with optional filtering by pattern
- ovs-appctl-dump-conntrack: Inspect connection tracking (conntrack)
  entries from the OVS datapath to debug stateful firewall rules and NAT
- ovs-appctl-ofproto-trace: Simulate packet processing through the
  OpenFlow pipeline to troubleshoot flow rules and forwarding decisions

These tools enable AI-assisted debugging of OVS networking issues without requiring direct cluster access.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>
Co-Authored-By: Claude <noreply@anthropic.com>

Example output:

```
● I'll help you list the bridges from every node by querying each ovnkube-node pod. Let me first get all the ovnkube-node pods in the ovn-kubernetes namespace.

● ovn-kubernetes - resource-list (MCP)(version: "v1", kind: "Pod", namespace: "ovn-kubernetes", labelSelector: "app=ovnkube-node")
  ⎿  {                             
       "resources": [
         {
     … +19 lines (ctrl+o to expand)

● Perfect! I found 3 ovnkube-node pods. Now let me list the bridges from each node:

● ovn-kubernetes - ovs-list-br (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-g96ld")
  ⎿  {                            
       "bridges": [
         "br-int",
     … +3 lines (ctrl+o to expand)

● ovn-kubernetes - ovs-list-br (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-kh724")
  ⎿  {                            
       "bridges": [
         "br-int",
     … +3 lines (ctrl+o to expand)

● ovn-kubernetes - ovs-list-br (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-qgn29")
  ⎿  {                            
       "bridges": [
         "br-int",
     … +3 lines (ctrl+o to expand)

● Here are the OVS bridges from each node:

  Node: ovnkube-node-g96ld
  - br-int
  - breth0

  Node: ovnkube-node-kh724
  - br-int
  - breth0

  Node: ovnkube-node-qgn29
  - br-int
  - breth0

  All three nodes have the same bridge configuration:
  - br-int: The OVN integration bridge (used for pod networking)
  - breth0: The external bridge (used for external connectivity)

  This is a typical OVN-Kubernetes setup. Would you like me to get more details about these bridges, such as their ports, interfaces, or OpenFlow rules?

> can you get ports and interfaces from br-int bridge from ovnkube-node-g96ld pod ? 

● I'll get both the ports and interfaces from the br-int bridge on the ovnkube-node-g96ld pod.

● ovn-kubernetes - ovs-list-ports (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-g96ld", bridge: "br-int")
  ⎿  {                            
       "ports": [
         "ovn-23cf3c-0",
     … +5 lines (ctrl+o to expand)

● ovn-kubernetes - ovs-list-ifaces (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-g96ld", bridge: "br-int")
  ⎿  {                            
       "interfaces": [
         "ovn-23cf3c-0",
     … +5 lines (ctrl+o to expand)

● Here are the ports and interfaces from the br-int bridge on ovnkube-node-g96ld:

  Ports:
  - ovn-23cf3c-0
  - ovn-c32ec4-0
  - ovn-k8s-mp0
  - patch-br-int-to-breth0_ovn-control-plane

  Interfaces:
  - ovn-23cf3c-0
  - ovn-c32ec4-0
  - ovn-k8s-mp0
  - patch-br-int-to-breth0_ovn-control-plane

  The ports and interfaces are the same, which is typical for OVS. Here's what these represent:
  - ovn-23cf3c-0 and ovn-c32ec4-0: Pod interfaces (connected to containers)
  - ovn-k8s-mp0: OVN-Kubernetes management port (used for node-to-pod communication)
  - patch-br-int-to-breth0_ovn-control-plane: Patch port connecting br-int to breth0 for external connectivity

  Would you like more details about any of these interfaces or see the OpenFlow flows on this bridge?

> what about from breth0 bridge ? 

● I'll get the ports and interfaces from the breth0 bridge on the ovnkube-node-g96ld pod.

● ovn-kubernetes - ovs-list-ports (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-g96ld", bridge: "breth0")
  ⎿  {                            
       "ports": [
         "eth0",
     … +3 lines (ctrl+o to expand)

● ovn-kubernetes - ovs-list-ifaces (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-g96ld", bridge: "breth0")
  ⎿  {                            
       "interfaces": [
         "eth0",
     … +3 lines (ctrl+o to expand)

● Here are the ports and interfaces from the breth0 bridge on ovnkube-node-g96ld:

  Ports:
  - eth0
  - patch-breth0_ovn-control-plane-to-br-int

  Interfaces:
  - eth0
  - patch-breth0_ovn-control-plane-to-br-int

  This shows the typical external bridge configuration:
  - eth0: The physical network interface of the node
  - patch-breth0_ovn-control-plane-to-br-int: Patch port connecting back to br-int (the other end of the patch we saw on br-int)

  The breth0 bridge acts as a gateway between the OVN overlay network (br-int) and the physical network (eth0), enabling external connectivity for pods.

  Would you like to see the OpenFlow flows on this bridge or get more detailed information about the OVS configuration?

> can you get ovs-vsctl show ? 

● I'll get the comprehensive OVS configuration using ovs-vsctl show from the ovnkube-node-g96ld pod.

● ovn-kubernetes - ovs-vsctl-show (MCP)(namespace: "ovn-kubernetes", name: "ovnkube-node-g96ld")
  ⎿ {                                                                                                                                                                                                                             
      "output": "12fd7edb-63b5-4b7f-89df-93385120112f\nBridge br-int\nfail_mode: secure\ndatapath_type: system\nPort ovn-c32ec4-0\nInterface ovn-c32ec4-0\ntype: geneve\noptions: {csum=\"true\", key=flow, local_ip=\"172.18.0.4\
    ", remote_ip=\"172.18.0.3\"}\nPort br-int\nInterface br-int\ntype: internal\nPort ovn-k8s-mp0\nInterface ovn-k8s-mp0\ntype: internal\nPort ovn-23cf3c-0\nInterface ovn-23cf3c-0\ntype: geneve\noptions: {csum=\"true\", key=fl
    … +4 lines (ctrl+o to expand)



● Here's the complete OVS configuration from ovnkube-node-g96ld:

  12fd7edb-63b5-4b7f-89df-93385120112f
  Bridge br-int
      fail_mode: secure
      datapath_type: system
      Port ovn-c32ec4-0
          Interface ovn-c32ec4-0
              type: geneve
              options: {csum="true", key=flow, local_ip="172.18.0.4", remote_ip="172.18.0.3"}
      Port br-int
          Interface br-int
              type: internal
      Port ovn-k8s-mp0
          Interface ovn-k8s-mp0
              type: internal
      Port ovn-23cf3c-0
          Interface ovn-23cf3c-0
              type: geneve
              options: {csum="true", key=flow, local_ip="172.18.0.4", remote_ip="172.18.0.2"}
      Port patch-br-int-to-breth0_ovn-control-plane
          Interface patch-br-int-to-breth0_ovn-control-plane
              type: patch
              options: {peer=patch-breth0_ovn-control-plane-to-br-int}
  Bridge breth0
      fail_mode: standalone
      Port eth0
          Interface eth0
      Port patch-breth0_ovn-control-plane-to-br-int
          Interface patch-breth0_ovn-control-plane-to-br-int
              type: patch
              options: {peer=patch-br-int-to-breth0_ovn-control-plane}
      Port breth0
          Interface breth0
              type: internal
  ovs_version: "3.4.1-1.fc42"

  Key observations:
  - OVS Version: 3.4.1-1.fc42
  - br-int has fail_mode: secure (drops packets when controller is disconnected)
  - breth0 has fail_mode: standalone (acts as normal switch when controller is disconnected)
  - Geneve tunnels: Two tunnels from local IP 172.18.0.4 to remote IPs 172.18.0.2 and 172.18.0.3 (connections to other nodes)
  - Patch ports: Connecting br-int and breth0 together

  Would you like to see OpenFlow flows or trace a packet through the pipeline?
```