### PR TITLE
Add external tools MCP server

### DIFF
--- a/pkg/kubernetes/mcp/nodes.go
+++ b/pkg/kubernetes/mcp/nodes.go
@@ -2,14 +2,61 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
 )
 
+// validatePath validates that a path is safe to use for mounting.
+// It ensures the path:
+// - Is absolute (starts with /)
+// - Does not contain path traversal patterns (..)
+// - Contains only safe characters
+func validatePath(path, pathType string) error {
+	if path == "" {
+		return nil // Empty paths are allowed and will be set to defaults
+	}
+
+	// Ensure path is absolute
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("%s must be an absolute path (start with /), got: %s", pathType, path)
+	}
+
+	// Check for path traversal patterns: reject any path element that is exactly ".."
+	for _, elem := range strings.Split(path, string(filepath.Separator)) {
+		if elem == ".." {
+			return fmt.Errorf("%s contains path traversal element '..': %s", pathType, path)
+		}
+	}
+
+	// Check for dangerous characters (null bytes, control characters, shell special characters)
+	for i, r := range path {
+		// Allow alphanumeric, /, -, _, ., ~
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			r == '/' || r == '-' || r == '_' || r == '.' || r == '~' {
+			continue
+		}
+		return fmt.Errorf("%s contains unsafe character at position %d: %c (U+%04X)", pathType, i, r, r)
+	}
+
+	return nil
+}
+
 // DebugNode debugs a node by name, image and command.
 func (s *MCPServer) DebugNode(ctx context.Context, req *mcp.CallToolRequest, in types.DebugNodeParams) (*mcp.CallToolResult, types.DebugNodeResult, error) {
-	stdout, stderr, err := s.clientSet.DebugNode(ctx, in.Name, in.Image, in.Command)
+	// Validate paths before creating the pod
+	if err := validatePath(in.HostPath, "hostPath"); err != nil {
+		return nil, types.DebugNodeResult{}, err
+	}
+
+	if err := validatePath(in.MountPath, "mountPath"); err != nil {
+		return nil, types.DebugNodeResult{}, err
+	}
+
+	stdout, stderr, err := s.clientSet.DebugNode(ctx, in.Name, in.Image, in.Command, in.HostPath, in.MountPath)
 	if err != nil {
 		return nil, types.DebugNodeResult{}, err
 	}

--- a/pkg/kubernetes/types/nodes.go
+++ b/pkg/kubernetes/types/nodes.go
@@ -2,9 +2,11 @@ package types
 
 // DebugNodeParams is a type that contains the name, image and command of a node.
 type DebugNodeParams struct {
-	Name    string   `json:"name"`
-	Image   string   `json:"image"`
-	Command []string `json:"command"`
+	Name      string   `json:"name"`
+	Image     string   `json:"image"`
+	Command   []string `json:"command"`
+	HostPath  string   `json:"hostPath,omitempty"`
+	MountPath string   `json:"mountPath,omitempty"`
 }
 
 // DebugNodeResult is a type that contains the stdout and stderr of the executed command.

--- a/pkg/nettools/mcp/mcp.go
+++ b/pkg/nettools/mcp/mcp.go
@@ -1,0 +1,76 @@
+package nettools
+
+import (
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
+)
+
+// MCPServer provides MCP server functionality for network tools operations.
+type MCPServer struct {
+	k8sMcpServer *kubernetesmcp.MCPServer
+	pwruImage    string
+	tcpdumpImage string
+}
+
+// NewMCPServer creates a new MCP server instance
+func NewMCPServer(k8sMcpServer *kubernetesmcp.MCPServer, pwruImage, tcpdumpImage string) *MCPServer {
+	return &MCPServer{
+		k8sMcpServer: k8sMcpServer,
+		pwruImage:    pwruImage,
+		tcpdumpImage: tcpdumpImage,
+	}
+}
+
+// AddTools registers network tools with the MCP server
+func (s *MCPServer) AddTools(server *mcp.Server) {
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "tcpdump",
+			Description: `Capture network packets on a node or inside a pod with strict safety controls.
+
+Supports both node-level and pod-level packet capture with BPF filtering.
+
+This tool creates a specialized debug pod on the specified node for node-level captures.
+The node image can be configured via --tcpdump-image flag or will default to nicolaka/netshoot:v0.13.
+The image must contain the tcpdump utility
+
+Parameters:
+- target_type: 'node' or 'pod' (required)
+- node_name: Name of the node (required when target_type is 'node')
+- pod_name: Name of the pod (required when target_type is 'pod')
+- pod_namespace: Namespace of the pod (required when target_type is 'pod')
+- container_name: Name of the container in the pod (optional, uses default container if not specified)
+- interface: Network interface name or 'any' (optional, uses default if not specified)
+- packet_count: Number of packets to capture (default: 100, max: 1000)
+- bpf_filter: BPF filter expression to match packets (optional, e.g., "tcp and dst port 8080", "host 10.0.0.1")
+- snaplen: Snapshot length in bytes (default: 96, max: 1500)
+
+Examples:
+- Capture on node: {"target_type": "node", "node_name": "worker-1", "interface": "eth0", "packet_count": 100, "bpf_filter": "tcp port 80"}
+- Capture in pod: {"target_type": "pod", "pod_name": "my-pod", "pod_namespace": "default", "interface": "eth0", "packet_count": 100, "bpf_filter": "host 10.0.0.1"}
+- Capture DNS: {"target_type": "node", "node_name": "worker-1", "interface": "any", "packet_count": 50, "bpf_filter": "port 53"}`,
+		}, s.Tcpdump)
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "pwru",
+			Description: `Trace packets through the Linux kernel networking stack using eBPF.
+
+pwru (packet, where are you?) shows which kernel functions process a packet, helping debug packet
+drops, routing issues, and understanding the kernel's packet processing path.
+
+This tool creates a specialized debug pod on the specified node with necessary eBPF capabilities
+to trace packets through kernel networking functions.
+The node image can be configured via --pwru-image flag or will default to docker.io/cilium/pwru:v1.0.10.
+The image must contain the pwru utility
+
+Parameters:
+- node_name: Name of the node to run pwru on (required)
+- bpf_filter: BPF filter expression to match packets (optional, e.g., "tcp and dst port 8080", "host 10.0.0.1")
+- output_limit_lines: Maximum number of trace events to capture (default: 100, max: 1000)
+
+Examples:
+- Basic trace: {"node_name": "worker-1", "bpf_filter": "host 10.244.0.5", "output_limit_lines": 100}
+- TCP traffic: {"node_name": "worker-1", "bpf_filter": "tcp and dst port 8080", "output_limit_lines": 50}
+- ICMP packets: {"node_name": "worker-1", "bpf_filter": "icmp", "output_limit_lines": 100}`,
+		}, s.Pwru)
+}

--- a/pkg/nettools/mcp/pwru.go
+++ b/pkg/nettools/mcp/pwru.go
@@ -1,0 +1,50 @@
+package nettools
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/nettools/types"
+)
+
+const (
+	DefaultOutputLimitLines = 100
+	MaxOutputLimitLines     = 1000
+)
+
+// Pwru executes the pwru (packet, where are you?) tool to trace packets through the Linux kernel.
+// It creates a specialized debug pod with eBPF capabilities and traces packet processing paths.
+// This is useful for debugging packet drops, routing issues, and understanding kernel networking behavior.
+func (s *MCPServer) Pwru(ctx context.Context, req *mcp.CallToolRequest, in types.PwruParams) (*mcp.CallToolResult, types.CommandResult, error) {
+	outputLimitLines := in.OutputLimitLines
+	if outputLimitLines == 0 {
+		outputLimitLines = DefaultOutputLimitLines
+	}
+	if err := validateIntMax(outputLimitLines, MaxOutputLimitLines, "output_limit_lines", ""); err != nil {
+		return nil, types.CommandResult{}, err
+	}
+
+	if err := validatePacketFilter(in.BPFFilter); err != nil {
+		return nil, types.CommandResult{}, err
+	}
+
+	cmd := newCommand("pwru", "--output-limit-lines", strconv.Itoa(outputLimitLines))
+	// pwru accepts pcap filter as positional argument(s)
+	cmd.addIfNotEmpty(in.BPFFilter, in.BPFFilter)
+
+	target := k8stypes.DebugNodeParams{
+		Name:      in.NodeName,
+		Image:     s.pwruImage,
+		HostPath:  "/sys/kernel/debug",
+		MountPath: "/sys/kernel/debug",
+		Command:   cmd.build(),
+	}
+
+	result, err := s.runDebugNode(ctx, req, target)
+	if err != nil {
+		return nil, types.CommandResult{}, err
+	}
+	return nil, result, nil
+}

--- a/pkg/nettools/mcp/tcpdump.go
+++ b/pkg/nettools/mcp/tcpdump.go
@@ -1,0 +1,82 @@
+package nettools
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/nettools/types"
+)
+
+const (
+	DefaultPacketCount = 100
+	MaxPacketCount     = 1000
+	// DefaultSnaplen is set to 96 bytes to capture headers (Ethernet + IP + TCP/UDP + some payload)
+	// This is sufficient for most diagnostic purposes while minimizing data capture
+	DefaultSnaplen = 96
+	// MaxSnaplen is set to 1500 bytes (standard Ethernet MTU) to allow full packet capture
+	// when needed for deeper analysis. Users can set snaplen parameter to capture complete packets.
+	MaxSnaplen = 1500
+)
+
+// Tcpdump executes the tcpdump packet capture tool on a node or inside a pod.
+func (s *MCPServer) Tcpdump(ctx context.Context, req *mcp.CallToolRequest, in types.TcpdumpParams) (*mcp.CallToolResult, types.CommandResult, error) {
+	if err := validateInterface(in.Interface); err != nil {
+		return nil, types.CommandResult{}, err
+	}
+	if err := validatePacketFilter(in.BPFFilter); err != nil {
+		return nil, types.CommandResult{}, err
+	}
+
+	packetCount := in.PacketCount
+	if packetCount == 0 {
+		packetCount = DefaultPacketCount
+	}
+	if err := validateIntMax(packetCount, MaxPacketCount, "packet_count", ""); err != nil {
+		return nil, types.CommandResult{}, err
+	}
+
+	snaplen := in.Snaplen
+	if snaplen == 0 {
+		snaplen = DefaultSnaplen
+	}
+	if err := validateIntMax(snaplen, MaxSnaplen, "snaplen", "bytes"); err != nil {
+		return nil, types.CommandResult{}, err
+	}
+
+	cmd := newCommand("tcpdump", "-n", "-v",
+		"-s", strconv.Itoa(snaplen),
+		"-c", strconv.Itoa(packetCount))
+	cmd.addIfNotEmpty(in.Interface, "-i", in.Interface)
+	cmd.addIfNotEmpty(in.BPFFilter, in.BPFFilter)
+
+	switch in.TargetType {
+	case "node":
+		result, err := s.runDebugNode(ctx, req, k8stypes.DebugNodeParams{
+			Name:    in.NodeName,
+			Image:   s.tcpdumpImage,
+			Command: cmd.build(),
+		})
+		if err != nil {
+			return nil, types.CommandResult{}, err
+		}
+		return nil, result, nil
+	case "pod":
+		result, err := s.runExecPod(ctx, req, k8stypes.ExecPodParams{
+			NamespacedNameParams: k8stypes.NamespacedNameParams{
+				Name:      in.PodName,
+				Namespace: in.PodNamespace,
+			},
+			Container: in.ContainerName,
+			Command:   cmd.build(),
+		})
+		if err != nil {
+			return nil, types.CommandResult{}, err
+		}
+		return nil, result, nil
+	default:
+		return nil, types.CommandResult{}, fmt.Errorf("invalid target_type: %s (must be 'node' or 'pod')", in.TargetType)
+	}
+}

--- a/pkg/nettools/mcp/utils.go
+++ b/pkg/nettools/mcp/utils.go
@@ -1,0 +1,138 @@
+package nettools
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/nettools/types"
+)
+
+var interfaceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// runDebugNode runs a command on a node
+func (s *MCPServer) runDebugNode(ctx context.Context, req *mcp.CallToolRequest, target k8stypes.DebugNodeParams) (types.CommandResult, error) {
+	if target.Name == "" {
+		return types.CommandResult{}, fmt.Errorf("node's name is required when target type is 'node'")
+	}
+	if target.Image == "" {
+		return types.CommandResult{}, fmt.Errorf("node's image is required when target type is 'node'")
+	}
+	_, output, err := s.k8sMcpServer.DebugNode(ctx, req, target)
+	if err != nil {
+		return types.CommandResult{}, err
+	}
+	return types.CommandResult{Output: output.Stdout}, nil
+}
+
+// runExecPod runs a command on a pod
+func (s *MCPServer) runExecPod(ctx context.Context, req *mcp.CallToolRequest, target k8stypes.ExecPodParams) (types.CommandResult, error) {
+	if target.NamespacedNameParams.Name == "" {
+		return types.CommandResult{}, fmt.Errorf("pod's name is required when target type is 'pod'")
+	}
+	if target.NamespacedNameParams.Namespace == "" {
+		target.NamespacedNameParams.Namespace = "default"
+	}
+	_, output, err := s.k8sMcpServer.ExecPod(ctx, req, target)
+	if err != nil {
+		return types.CommandResult{}, err
+	}
+	return types.CommandResult{Output: output.Stdout}, nil
+}
+
+// commandBuilder helps build commands with a fluent interface
+type commandBuilder struct {
+	args []string
+}
+
+// newCommand creates a new command builder with the base command
+func newCommand(baseCmd ...string) *commandBuilder {
+	return &commandBuilder{args: baseCmd}
+}
+
+// add adds arguments to the command
+func (cb *commandBuilder) add(args ...string) *commandBuilder {
+	cb.args = append(cb.args, args...)
+	return cb
+}
+
+// addIf adds arguments to the command only if the condition is true
+func (cb *commandBuilder) addIf(condition bool, args ...string) *commandBuilder {
+	if condition {
+		cb.args = append(cb.args, args...)
+	}
+	return cb
+}
+
+// addIfNotEmpty adds arguments to the command only if the value is not empty
+func (cb *commandBuilder) addIfNotEmpty(value string, args ...string) *commandBuilder {
+	if value != "" {
+		cb.args = append(cb.args, args...)
+	}
+	return cb
+}
+
+// build returns the final command slice
+func (cb *commandBuilder) build() []string {
+	return cb.args
+}
+
+// validateInterface validates a network interface name for security and correctness.
+func validateInterface(iface string) error {
+	if iface == "" {
+		return nil
+	}
+	if iface == "any" {
+		return nil
+	}
+	if len(iface) > 15 {
+		return fmt.Errorf("interface name too long: %s", iface)
+	}
+	if !interfaceNamePattern.MatchString(iface) {
+		return fmt.Errorf("invalid interface name: %s", iface)
+	}
+	return nil
+}
+
+// validatePacketFilter validates a packet filter expression for security.
+func validatePacketFilter(filter string) error {
+	if filter == "" {
+		return nil
+	}
+	if len(filter) > 1024 {
+		return fmt.Errorf("packet filter too long (max 1024 characters)")
+	}
+
+	dangerous := []string{";", "|", "&", "`", "$", "$(", "\n", "\x00", ">", "<", "'", "\""}
+	for _, pattern := range dangerous {
+		if strings.Contains(filter, pattern) {
+			return fmt.Errorf("packet filter contains potentially dangerous characters")
+		}
+	}
+	return nil
+}
+
+// validateIntMax checks if a value exceeds the maximum or is negative and returns an error if it does
+func validateIntMax(value, max int, fieldName, unit string) error {
+	if value < 0 {
+		return fmt.Errorf("%s cannot be negative", fieldName)
+	}
+	if value > max {
+		if unit != "" {
+			return fmt.Errorf("%s cannot exceed %d %s", fieldName, max, unit)
+		}
+		return fmt.Errorf("%s cannot exceed %d", fieldName, max)
+	}
+	return nil
+}
+
+// stringWithDefault returns the value if non-empty, otherwise returns the default
+func stringWithDefault(value, defaultValue string) string {
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}

--- a/pkg/nettools/mcp/utils_test.go
+++ b/pkg/nettools/mcp/utils_test.go
@@ -1,0 +1,568 @@
+package nettools
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestValidateIntMax(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     int
+		max       int
+		fieldName string
+		unit      string
+		wantErr   bool
+	}{
+		{
+			name:      "zero value",
+			value:     0,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   false,
+		},
+		{
+			name:      "minimum valid value",
+			value:     1,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   false,
+		},
+		{
+			name:      "value below max",
+			value:     10,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   false,
+		},
+		{
+			name:      "value equals max",
+			value:     30,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   false,
+		},
+		{
+			name:      "value just over max",
+			value:     31,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   true,
+		},
+		{
+			name:      "value exceeds max with unit",
+			value:     100,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   true,
+		},
+		{
+			name:      "value exceeds max without unit",
+			value:     1001,
+			max:       1000,
+			fieldName: "packet_count",
+			unit:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "negative value -1",
+			value:     -1,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   true,
+		},
+		{
+			name:      "large negative value",
+			value:     -100,
+			max:       30,
+			fieldName: "duration",
+			unit:      "seconds",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIntMax(tt.value, tt.max, tt.fieldName, tt.unit)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateIntMax() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestStringWithDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		defaultValue string
+		want         string
+	}{
+		{
+			name:         "empty value returns default",
+			value:        "",
+			defaultValue: "text",
+			want:         "text",
+		},
+		{
+			name:         "non-empty value returns value",
+			value:        "pcap",
+			defaultValue: "text",
+			want:         "pcap",
+		},
+		{
+			name:         "both empty returns empty",
+			value:        "",
+			defaultValue: "",
+			want:         "",
+		},
+		{
+			name:         "whitespace value returns value",
+			value:        " ",
+			defaultValue: "text",
+			want:         " ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringWithDefault(tt.value, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("stringWithDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateInterface(t *testing.T) {
+	tests := []struct {
+		name      string
+		iface     string
+		wantError bool
+	}{
+		// Valid interface names
+		{
+			name:      "empty interface",
+			iface:     "",
+			wantError: false,
+		},
+		{
+			name:      "any interface",
+			iface:     "any",
+			wantError: false,
+		},
+		{
+			name:      "valid eth0",
+			iface:     "eth0",
+			wantError: false,
+		},
+		{
+			name:      "valid interface with dot",
+			iface:     "eth0.100",
+			wantError: false,
+		},
+		{
+			name:      "valid interface with underscore",
+			iface:     "br_ex",
+			wantError: false,
+		},
+		{
+			name:      "valid interface with hyphen",
+			iface:     "veth-abc",
+			wantError: false,
+		},
+		{
+			name:      "valid interface wlan0",
+			iface:     "wlan0",
+			wantError: false,
+		},
+		{
+			name:      "valid interface lo",
+			iface:     "lo",
+			wantError: false,
+		},
+		{
+			name:      "valid interface br-int",
+			iface:     "br-int",
+			wantError: false,
+		},
+		{
+			name:      "valid interface with numbers",
+			iface:     "veth123abc",
+			wantError: false,
+		},
+		{
+			name:      "valid 15 character interface",
+			iface:     "123456789012345",
+			wantError: false,
+		},
+		// Invalid interface names
+		{
+			name:      "interface too long (16 chars)",
+			iface:     "1234567890123456",
+			wantError: true,
+		},
+		{
+			name:      "interface too long",
+			iface:     "verylonginterfacename",
+			wantError: true,
+		},
+		{
+			name:      "interface with semicolon",
+			iface:     "eth;0",
+			wantError: true,
+		},
+		{
+			name:      "interface with space",
+			iface:     "eth 0",
+			wantError: true,
+		},
+		{
+			name:      "interface starting with hyphen",
+			iface:     "-eth0",
+			wantError: true,
+		},
+		{
+			name:      "interface starting with dot",
+			iface:     ".eth0",
+			wantError: true,
+		},
+		{
+			name:      "interface starting with underscore",
+			iface:     "_eth0",
+			wantError: true,
+		},
+		{
+			name:      "interface with pipe",
+			iface:     "eth|0",
+			wantError: true,
+		},
+		{
+			name:      "interface with ampersand",
+			iface:     "eth&0",
+			wantError: true,
+		},
+		{
+			name:      "interface with backtick",
+			iface:     "eth`0",
+			wantError: true,
+		},
+		{
+			name:      "interface with dollar sign",
+			iface:     "eth$0",
+			wantError: true,
+		},
+		{
+			name:      "interface with newline",
+			iface:     "eth0\n",
+			wantError: true,
+		},
+		{
+			name:      "interface with parentheses",
+			iface:     "eth(0)",
+			wantError: true,
+		},
+		{
+			name:      "interface with brackets",
+			iface:     "eth[0]",
+			wantError: true,
+		},
+		{
+			name:      "interface with slash",
+			iface:     "eth/0",
+			wantError: true,
+		},
+		{
+			name:      "interface with backslash",
+			iface:     "eth\\0",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInterface(tt.iface)
+			if (err != nil) != tt.wantError {
+				t.Errorf("validateInterface(%q) error = %v, wantError %v", tt.iface, err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidatePacketFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    string
+		wantError bool
+	}{
+		// Valid filters
+		{
+			name:      "empty filter",
+			filter:    "",
+			wantError: false,
+		},
+		{
+			name:      "simple tcp filter",
+			filter:    "tcp port 80",
+			wantError: false,
+		},
+		{
+			name:      "simple udp filter",
+			filter:    "udp port 53",
+			wantError: false,
+		},
+		{
+			name:      "simple icmp filter",
+			filter:    "icmp",
+			wantError: false,
+		},
+		{
+			name:      "filter with host",
+			filter:    "host 192.168.1.1",
+			wantError: false,
+		},
+		{
+			name:      "filter with host and port",
+			filter:    "host 10.0.0.1 and port 80",
+			wantError: false,
+		},
+		{
+			name:      "filter with src and dst",
+			filter:    "src 10.0.0.1 and dst 10.0.0.2",
+			wantError: false,
+		},
+		{
+			name:      "complex filter with or",
+			filter:    "tcp port 80 or udp port 53",
+			wantError: false,
+		},
+		{
+			name:      "complex filter with and",
+			filter:    "tcp and port 443 and host 10.0.0.1",
+			wantError: false,
+		},
+		{
+			name:      "filter with parentheses",
+			filter:    "(tcp port 80) and (host 10.0.0.1)",
+			wantError: false,
+		},
+		{
+			name:      "filter with not",
+			filter:    "not port 22",
+			wantError: false,
+		},
+		{
+			name:      "filter with port range",
+			filter:    "portrange 8000-9000",
+			wantError: false,
+		},
+		{
+			name:      "filter with greater/less operators",
+			filter:    "greater 100",
+			wantError: false,
+		},
+		{
+			name:      "filter with net",
+			filter:    "net 192.168.0.0/24",
+			wantError: false,
+		},
+		{
+			name:      "filter with vlan",
+			filter:    "vlan 100",
+			wantError: false,
+		},
+		{
+			name:      "filter with ip proto",
+			filter:    "ip proto 6",
+			wantError: false,
+		},
+		{
+			name:      "filter with ether",
+			filter:    "ether host ff:ff:ff:ff:ff:ff",
+			wantError: false,
+		},
+		{
+			name:      "filter with broadcast",
+			filter:    "broadcast",
+			wantError: false,
+		},
+		{
+			name:      "filter with multicast",
+			filter:    "multicast",
+			wantError: false,
+		},
+		{
+			name:      "complex nested filter",
+			filter:    "((tcp and port 80) or (udp and port 53)) and host 10.0.0.1",
+			wantError: false,
+		},
+		{
+			name:      "filter with IPv6",
+			filter:    "ip6 and host 2001:db8::1",
+			wantError: false,
+		},
+		{
+			name:      "filter with less",
+			filter:    "less 100",
+			wantError: false,
+		},
+		// Invalid filters - command injection attempts
+		{
+			name:      "invalid filter - semicolon injection",
+			filter:    "tcp port 80; rm -rf /",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - pipe injection",
+			filter:    "tcp port 80 | cat",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - ampersand injection",
+			filter:    "tcp port 80 & ls",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - backtick injection",
+			filter:    "tcp port `echo 80`",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - dollar sign injection",
+			filter:    "tcp port $PORT",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - command substitution",
+			filter:    "tcp port $(echo 80)",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - newline injection",
+			filter:    "tcp port 80\nrm -rf /",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - null byte injection",
+			filter:    "tcp port 80\x00rm -rf /",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - double pipe",
+			filter:    "tcp port 80 || ls",
+			wantError: true,
+		},
+		{
+			name:      "invalid filter - double ampersand",
+			filter:    "tcp port 80 && ls",
+			wantError: true,
+		},
+		// Invalid filters - length validation
+		{
+			name:      "filter at max length (1024 chars)",
+			filter:    strings.Repeat("a", 1024),
+			wantError: false,
+		},
+		{
+			name:      "filter exceeds max length (1025 chars)",
+			filter:    strings.Repeat("a", 1025),
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePacketFilter(tt.filter)
+			if (err != nil) != tt.wantError {
+				t.Errorf("validatePacketFilter(%q) error = %v, wantError %v", tt.filter, err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestCommandBuilder(t *testing.T) {
+	tests := []struct {
+		name    string
+		builder func() *commandBuilder
+		want    []string
+	}{
+		{
+			name: "simple command",
+			builder: func() *commandBuilder {
+				return newCommand("tcpdump")
+			},
+			want: []string{"tcpdump"},
+		},
+		{
+			name: "command with args",
+			builder: func() *commandBuilder {
+				return newCommand("tcpdump").add("-i", "eth0")
+			},
+			want: []string{"tcpdump", "-i", "eth0"},
+		},
+		{
+			name: "command with conditional args true",
+			builder: func() *commandBuilder {
+				return newCommand("tcpdump").addIf(true, "-v")
+			},
+			want: []string{"tcpdump", "-v"},
+		},
+		{
+			name: "command with conditional args false",
+			builder: func() *commandBuilder {
+				return newCommand("tcpdump").addIf(false, "-v")
+			},
+			want: []string{"tcpdump"},
+		},
+		{
+			name: "command with addIfNotEmpty with value",
+			builder: func() *commandBuilder {
+				return newCommand("tcpdump").addIfNotEmpty("tcp port 80", "tcp port 80")
+			},
+			want: []string{"tcpdump", "tcp port 80"},
+		},
+		{
+			name: "command with addIfNotEmpty without value",
+			builder: func() *commandBuilder {
+				return newCommand("tcpdump").addIfNotEmpty("", "-f")
+			},
+			want: []string{"tcpdump"},
+		},
+		{
+			name: "command with chained operations",
+			builder: func() *commandBuilder {
+				return newCommand("tcpdump").
+					add("-i", "eth0").
+					addIf(true, "-n").
+					addIf(false, "-v").
+					addIfNotEmpty("tcp", "tcp").
+					addIfNotEmpty("", "-x")
+			},
+			want: []string{"tcpdump", "-i", "eth0", "-n", "tcp"},
+		},
+		{
+			name: "command with multiple base args",
+			builder: func() *commandBuilder {
+				return newCommand("timeout", "30s", "retis")
+			},
+			want: []string{"timeout", "30s", "retis"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.builder().build()
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("commandBuilder.build() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/nettools/types/manifest.go
+++ b/pkg/nettools/types/manifest.go
@@ -1,0 +1,42 @@
+package types
+
+// BaseNetworkDiagParams contains common parameters shared across network diagnostic tools.
+type BaseNetworkDiagParams struct {
+	BPFFilter string `json:"bpf_filter,omitempty"`
+}
+
+// TcpdumpParams contains parameters for running tcpdump packet capture.
+// Supports both node-level and pod-level packet capture with BPF filtering.
+type TcpdumpParams struct {
+	BaseNetworkDiagParams
+
+	TargetType string `json:"target_type"`
+
+	// Node-specific fields
+	NodeName string `json:"node_name,omitempty"`
+
+	// Pod-specific fields
+	PodName       string `json:"pod_name,omitempty"`
+	PodNamespace  string `json:"pod_namespace,omitempty"`
+	ContainerName string `json:"container_name,omitempty"`
+
+	Interface   string `json:"interface,omitempty"`
+	PacketCount int    `json:"packet_count,omitempty"`
+	Snaplen     int    `json:"snaplen,omitempty"`
+}
+
+// PwruParams contains parameters for running pwru (packet, where are you?) eBPF-based
+// kernel packet tracing. This tool traces packets through the Linux kernel networking stack.
+type PwruParams struct {
+	BaseNetworkDiagParams
+
+	NodeName         string `json:"node_name"`
+	OutputLimitLines int    `json:"output_limit_lines,omitempty"`
+}
+
+// CommandResult represents the output and status of an executed command.
+type CommandResult struct {
+	Output   string `json:"output"`
+	ExitCode int    `json:"exit_code,omitempty"`
+	Error    string `json:"error,omitempty"`
+}


### PR DESCRIPTION
This PR add network external tools: tcpdump and pwru
- tcpdump: Capture and analyze network packets with BPF filters
- pwru: allows fine-grained introspection of kernel state to facilitate debugging network connectivity issues.

Test with Claude Code, it can work well
```
● I'll run tcpdump on the ovn-worker node with the parameters you specified.

● ovn-kubernetes - tcpdump (MCP)(target_type: "node", node_name: "ovn-worker", node_image: "docker.io/nicolaka/netshoot:latest", interface: "any", packet_count: 100, duration: 10)
  ⎿ {                                                                                                                                                                                                          
      "output": "07:22:58.893687 lo    In  IP (tos 0x0, ttl 64, id 12134, offset 0, flags [DF], proto TCP (6), length 56)\n    127.0.0.1.39215 > 127.0.0.1.53410: Flags [P.], cksum 0xfe2c (incorrect -> 0x9946
    ), seq 760435588:760435592, ack 2125033155, win 64, options [nop,nop,TS val 1524508863 ecr 1524508817], length 4\n07:22:58.893739 lo    In  IP (tos 0x0, ttl 64, id 12135, offset 0, flags [DF], proto TCP
    … +131 lines (ctrl+o to expand)


● Perfect! The tcpdump completed successfully on the ovn-worker node. I captured 100 packets over the 10-second duration.

  Summary of captured traffic:

  - Loopback (lo): TCP traffic on 127.0.0.1 (local connections)
  - breth0: OVN bridge interface traffic between nodes (172.18.0.3 ↔ 172.18.0.4)
  - eth0: Physical network interface traffic

  Key observations:
  - Port 10250: Kubelet API traffic (172.18.0.3 → 172.18.0.4)
  - Port 6443: Kubernetes API server traffic (172.18.0.3 → 172.18.0.4)
  - TCP connections showing normal cluster communication patterns
```

```
● I'll analyze network packets on the ovn-worker node using pwru to trace TCP traffic to destination port 8080.

● ovn-kubernetes - pwru (MCP)(node_name: "ovn-worker", pcap_filter: "tcp and dst port 8080", output_limit_lines: 100)
  ⎿ {                                                                                                                                                                                                          
      "output": "SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   TUPLE FUNC\n0xffff88c6ca1962e8 8   <empty>:37034    4026533011 0               0         0x000
    0 65536 60    127.0.0.1:37608->127.0.0.1:8080(tcp) __ip_local_out\n0xffff88c6ca1962e8 8   <empty>:37034    4026533011 0               0         0x0800 65536 60    127.0.0.1:37608->127.0.0.1:8080(tcp) nf_
    … +75 lines (ctrl+o to expand)



● I've successfully traced TCP packets to port 8080 on the ovn-worker node using pwru. Here's what the analysis reveals:

  Traffic Characteristics

  - Connection: Localhost traffic from 127.0.0.1:37608 → 127.0.0.1:8080
  - Network Namespace: Traffic originates in netns 4026533011, then transitions to root netns (0)
  - Protocol: TCP connection establishment (SYN packets visible)

  Kernel Path Analysis

  Outbound Path

  1. __ip_local_out - Local IP output initialization
  2. nf_hook_slow - Netfilter hooks (OUTPUT chain)
  3. ip_output → ip_finish_output - IP layer processing
  4. __dev_queue_xmit - Queuing for transmission
  5. loopback_xmit - Loopback device transmission

  Inbound Path

  1. __netif_rx - Receive packet from device
  2. __netif_receive_skb - Core receive processing
  3. ip_rcv - IP layer receive
  4. ip_local_deliver - Deliver to local stack
  5. tcp_v4_rcv - TCP layer processing

  TCP Processing

  - tcp_conn_request - Connection request handling
  - tcp_rcv_state_process - TCP state machine
  - __inet_lookup_listener - Socket lookup for listening port 8080
  - reuseport_select_sock - SO_REUSEPORT socket selection

  Security Checks

  - Multiple SELinux checkpoints: selinux_ip_output, selinux_socket_sock_rcv_skb, selinux_inet_conn_request
  - eBPF LSM hooks: bpf_lsm_socket_sock_rcv_skb, bpf_lsm_inet_conn_request

  The trace shows healthy TCP connection establishment to a local service listening on port 8080, with all packets successfully traversing the kernel networking stack without drops.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tcpdump and pwru network diagnostic tools (node/pod targets) with MCP registration and image configuration via new CLI flags.
* **Bug Fixes / Security**
  * Stronger validation for paths, interfaces, BPF filters, and numeric bounds; reduced debug pod timeout.
* **API**
  * Exposed parameter structures and standardized command result format for network diagnostics.
* **Tests**
  * Added comprehensive unit tests for validation utilities and the command-builder.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->