### PR TITLE
Add kernel MCP tools

### DIFF
--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	kernelmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/mcp"
 	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
 	ovsmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovs/mcp"
 	sosreportmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/mcp"
@@ -41,6 +42,10 @@ func main() {
 		ovsServer := ovsmcp.NewMCPServer(k8sMcpServer)
 		log.Println("Adding OVS tools to OVN-K MCP server")
 		ovsServer.AddTools(ovnkMcpServer)
+
+		kernelMcpServer := kernelmcp.NewMCPServer(k8sMcpServer)
+		log.Println("Adding Kernel tools to OVN-K MCP server")
+		kernelMcpServer.AddTools(ovnkMcpServer)
 	}
 	if serverCfg.Mode == "offline" {
 		sosreportServer := sosreportmcp.NewMCPServer()

--- a/pkg/kernel/mcp/conntrack.go
+++ b/pkg/kernel/mcp/conntrack.go
@@ -1,0 +1,99 @@
+package kernel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/types"
+)
+
+const conntrackSystemFile = "/proc/net/nf_conntrack"
+
+// GetConntrack MCP handler for conntrack operations.
+// GetConntrack retrieves connection tracking entries from a Kubernetes node.
+// TODO: Add support for conntrack event monitoring (-E flag).
+// TODO: Add support for -G (get specific entry) command.
+func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, in types.ListConntrackParams) (*mcp.CallToolResult, types.Result, error) {
+	// Falls back to /proc/net/nf_conntrack parsing when conntrack CLI unavailable.
+	conntrackCliAvailable, _ := s.UtilityExists(ctx, req, in.Node, in.Image, "conntrack")
+	if err := validateConntrackCommand(in.Command, conntrackCliAvailable); err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
+	}
+	if in.FilterParameters != "" {
+		if err := validateParameters(in.FilterParameters); err != nil {
+			return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
+		}
+	}
+
+	var stdout string
+	var err error
+	if !conntrackCliAvailable {
+		stdout, err = s.getConntrackFromFile(ctx, req, in.Node, in.Image)
+		if err != nil {
+			return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
+		}
+	} else {
+		stdout, err = s.getConntrackUsingCLI(ctx, req, in.Node, in.Image, in.Command, in.FilterParameters)
+		if err != nil {
+			return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
+		}
+	}
+	stdout = limitOutputLines(stdout, in.MaxLines)
+	return nil, types.Result{Data: stdout}, nil
+}
+
+// getConntrackUsingCLI executes conntrack CLI commands.
+func (s *MCPServer) getConntrackUsingCLI(ctx context.Context, req *mcp.CallToolRequest, node, image, command, filterParameters string) (string, error) {
+	cmd := newCommand("conntrack")
+	switch command {
+	case "-L", "--dump":
+		cmd.add(command)
+		cmd.add(strings.Fields(filterParameters)...)
+	case "-S", "--stats":
+		cmd.add(command)
+	case "-C", "--count":
+		cmd.add(command)
+	default:
+		cmd.add("-L")
+		cmd.add(strings.Fields(filterParameters)...)
+	}
+	return s.executeCommand(ctx, req, node, image, cmd.build())
+}
+
+// getConntrackFromFile parses /proc/net/nf_conntrack directly.
+// TODO: Add filter support while getting conntrack entries from /proc/net/nf_conntrack.
+func (s *MCPServer) getConntrackFromFile(ctx context.Context, req *mcp.CallToolRequest, node, image string) (string, error) {
+	cmd := newCommand("cat")
+	cmd.add(conntrackSystemFile)
+	return s.executeCommand(ctx, req, node, image, cmd.build())
+}
+
+// validateConntrackCommand validates the command to be used to get list of conntrack entries.
+// It returns an error if conntrack CLI is not available and any other operation than list is being performed.
+func validateConntrackCommand(command string, cliAvailable bool) error {
+	if command == "" {
+		return nil
+	}
+	if !cliAvailable && (strings.TrimSpace(command) != "-L" && strings.TrimSpace(command) != "--dump") {
+		return fmt.Errorf("mentioned image does not have conntrack utility, only -L is supported with limited filters")
+	}
+	if _, err := strconv.Atoi(command); err == nil {
+		return fmt.Errorf("invalid command: %s", command)
+	}
+	validTables := map[string]bool{
+		"-L":      true,
+		"-S":      true,
+		"-C":      true,
+		"--dump":  true,
+		"--stats": true,
+		"--count": true,
+	}
+
+	if !validTables[strings.TrimSpace(command)] {
+		return fmt.Errorf("invalid command: %s", command)
+	}
+	return nil
+}

--- a/pkg/kernel/mcp/conntrack_test.go
+++ b/pkg/kernel/mcp/conntrack_test.go
@@ -1,0 +1,150 @@
+package kernel
+
+import (
+	"testing"
+)
+
+func TestValidateConntrackCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      string
+		cliAvailable bool
+		wantError    bool
+	}{
+		{
+			name:         "empty string with CLI available",
+			command:      "",
+			cliAvailable: true,
+			wantError:    false,
+		},
+		{
+			name:         "empty string without CLI",
+			command:      "",
+			cliAvailable: false,
+			wantError:    false,
+		},
+		{
+			name:         "numeric string with CLI available",
+			command:      "321",
+			cliAvailable: true,
+			wantError:    true,
+		},
+		{
+			name:         "numeric string without CLI",
+			command:      "321",
+			cliAvailable: false,
+			wantError:    true,
+		},
+		{
+			name:         "valid command --dump with CLI available",
+			command:      "--dump",
+			cliAvailable: true,
+			wantError:    false,
+		},
+		{
+			name:         "valid command --dump without CLI",
+			command:      "--dump",
+			cliAvailable: false,
+			wantError:    false,
+		},
+		{
+			name:         "valid command --stats with CLI available",
+			command:      "--stats",
+			cliAvailable: true,
+			wantError:    false,
+		},
+		{
+			name:         "valid command --stats without CLI",
+			command:      "--stats",
+			cliAvailable: false,
+			wantError:    true,
+		},
+		{
+			name:         "valid command --count with CLI available",
+			command:      "--count",
+			cliAvailable: true,
+			wantError:    false,
+		},
+		{
+			name:         "valid command --count without CLI",
+			command:      "--count",
+			cliAvailable: false,
+			wantError:    true,
+		},
+		{
+			name:         "valid command -L with CLI available",
+			command:      "-L",
+			cliAvailable: true,
+			wantError:    false,
+		},
+		{
+			name:         "valid command -L without CLI",
+			command:      "-L",
+			cliAvailable: false,
+			wantError:    false,
+		},
+		{
+			name:         "valid command -S with CLI available",
+			command:      "-S",
+			cliAvailable: true,
+			wantError:    false,
+		},
+		{
+			name:         "valid command -S without CLI",
+			command:      "-S",
+			cliAvailable: false,
+			wantError:    true,
+		},
+		{
+			name:         "valid command -C with CLI available",
+			command:      "-C",
+			cliAvailable: true,
+			wantError:    false,
+		},
+		{
+			name:         "valid command -C without CLI",
+			command:      "-C",
+			cliAvailable: false,
+			wantError:    true,
+		},
+		{
+			name:         "invalid command with CLI available",
+			command:      "-E",
+			cliAvailable: true,
+			wantError:    true,
+		},
+		{
+			name:         "invalid command without CLI",
+			command:      "-E",
+			cliAvailable: false,
+			wantError:    true,
+		},
+		{
+			name:         "invalid command -D with CLI available",
+			command:      "-D",
+			cliAvailable: true,
+			wantError:    true,
+		},
+		{
+			name:         "lowercase -l with CLI available",
+			command:      "-l",
+			cliAvailable: true,
+			wantError:    true,
+		},
+		{
+			name:         "command with spaces",
+			command:      "-L ",
+			cliAvailable: true,
+			wantError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConntrackCommand(tt.command, tt.cliAvailable)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateConntrackCommand(%q, %v) error = %v, wantError %v", tt.command, tt.cliAvailable, err, tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/kernel/mcp/ip.go
+++ b/pkg/kernel/mcp/ip.go
@@ -1,0 +1,114 @@
+package kernel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/types"
+)
+
+// GetIPCommandOutput MCP handler for ip utility operations.
+// GetIPCommandOutput executes 'ip' utility commands on a node.
+// Requires ip utility in the debug container image.
+func (s *MCPServer) GetIPCommandOutput(ctx context.Context, req *mcp.CallToolRequest, in types.ListIPParams) (*mcp.CallToolResult, types.Result, error) {
+	ipCliAvailable, err := s.UtilityExists(ctx, req, in.Node, in.Image, "ip")
+	if !ipCliAvailable {
+		return nil, types.Result{}, fmt.Errorf("error while getting ip data: mentioned image does not have ip utility: %w", err)
+	}
+
+	if err := validateIPCommand(in.Command); err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting ip data: %w", err)
+	}
+	if in.FilterParameters != "" {
+		if err := validateParameters(in.FilterParameters); err != nil {
+			return nil, types.Result{}, fmt.Errorf("error while getting ip data: %w", err)
+		}
+	}
+	if in.Options != "" {
+		if err := validateParameters(in.Options); err != nil {
+			return nil, types.Result{}, fmt.Errorf("error while getting ip data: %w", err)
+		}
+	}
+
+	cmd := newCommand("ip")
+	cmd.addIfNotEmpty(in.Options, in.Options)
+	cmd.add(strings.Fields(in.Command)...)
+	cmd.addIfNotEmpty(in.FilterParameters, strings.Fields(in.FilterParameters)...)
+
+	stdout, err := s.executeCommand(ctx, req, in.Node, in.Image, cmd.build())
+	if err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting ip data: %w", err)
+	}
+	stdout = limitOutputLines(stdout, in.MaxLines)
+	return nil, types.Result{Data: stdout}, nil
+}
+
+// validateIPCommand validates that the IP command is allowed.
+func validateIPCommand(ipCommand string) error {
+	if _, err := strconv.Atoi(ipCommand); err == nil {
+		return fmt.Errorf("invalid ip command: %s", ipCommand)
+	}
+	splitCommand := strings.Fields(strings.TrimSpace(ipCommand))
+	if len(splitCommand) < 2 {
+		return fmt.Errorf("invalid ip command: %s", ipCommand)
+	}
+	validIpCommand := map[string]bool{
+		"address":     true,
+		"link":        true,
+		"neighbour":   true,
+		"netns":       true,
+		"route":       true,
+		"rule":        true,
+		"vrf":         true,
+		"xfrm state":  true,
+		"xfrm policy": true,
+	}
+
+	// "ip l s" can be used to set a link up or down. This should be considered as an invalid command.
+	if strings.HasPrefix(splitCommand[0], "l") && splitCommand[1] == "s" {
+		return fmt.Errorf("invalid ip command: %s", ipCommand)
+	}
+
+	var valid bool
+	for command := range validIpCommand {
+		commandFields := strings.Fields(command)
+		// Check if the input command matches the expected command pattern
+		// For single-word commands like "address", we check: splitCommand[0] matches "address" and splitCommand[1] matches "show"
+		// For multi-word xfrm commands, we check: splitCommand[0:2] matches ["xfrm", "state"/"policy"] and splitCommand[2] matches "list"
+
+		if len(commandFields) == 1 {
+			// Single-word command (e.g., "address show", "link show")
+			if strings.HasPrefix(command, splitCommand[0]) && strings.HasPrefix("show", splitCommand[1]) {
+				valid = true
+				break
+			}
+		} else {
+			// Multi-word command (e.g., "xfrm state list", "xfrm policy list")
+			// Need at least len(commandFields) + 1 words (command words + subcommand)
+			if len(splitCommand) >= len(commandFields)+1 {
+				allMatch := true
+				for i, cmdField := range commandFields {
+					if !strings.HasPrefix(cmdField, splitCommand[i]) {
+						allMatch = false
+						break
+					}
+				}
+				// For xfrm state and xfrm policy, only accept "list"
+				if allMatch && (command == "xfrm state" || command == "xfrm policy") {
+					if strings.HasPrefix("list", splitCommand[len(commandFields)]) {
+						valid = true
+						break
+					}
+				}
+			}
+		}
+	}
+	if !valid {
+		return fmt.Errorf("invalid ip command: %s", ipCommand)
+	}
+
+	return nil
+}

--- a/pkg/kernel/mcp/ip_test.go
+++ b/pkg/kernel/mcp/ip_test.go
@@ -1,0 +1,228 @@
+package kernel
+
+import (
+	"testing"
+)
+
+func TestValidateIPCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		ipCommand string
+		wantError bool
+	}{
+		{
+			name:      "empty string",
+			ipCommand: "",
+			wantError: true,
+		},
+		{
+			name:      "numeric string",
+			ipCommand: "999",
+			wantError: true,
+		},
+		{
+			name:      "valid command - address show",
+			ipCommand: "address show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - link show",
+			ipCommand: "link show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - neighbour show",
+			ipCommand: "neighbour show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - netns show",
+			ipCommand: "netns show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - route show",
+			ipCommand: "route show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - rule show",
+			ipCommand: "rule show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - vrf show",
+			ipCommand: "vrf show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - addr show",
+			ipCommand: "addr show",
+			wantError: false,
+		},
+		{
+			name:      "invalid command - neighbor show",
+			ipCommand: "neighbor show",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - address add",
+			ipCommand: "address add",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - link set",
+			ipCommand: "link set",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - route add",
+			ipCommand: "route add",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - just address",
+			ipCommand: "address",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - uppercase",
+			ipCommand: "ADDRESS SHOW",
+			wantError: true,
+		},
+		{
+			name:      "valid command - address show with extra spaces",
+			ipCommand: "address  show",
+			wantError: false,
+		},
+		{
+			name:      "valid command - with trailing space",
+			ipCommand: "address show ",
+			wantError: false,
+		},
+		{
+			name:      "valid command - abbreviated with spaces",
+			ipCommand: "n s",
+			wantError: false,
+		},
+		{
+			name:      "invalid command - l s (can set link)",
+			ipCommand: "l s",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - xfrm state show",
+			ipCommand: "xfrm state show",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - xfrm policy show",
+			ipCommand: "xfrm policy show",
+			wantError: true,
+		},
+		{
+			name:      "valid command - xfrm state list",
+			ipCommand: "xfrm state list",
+			wantError: false,
+		},
+		{
+			name:      "valid command - xfrm policy list",
+			ipCommand: "xfrm policy list",
+			wantError: false,
+		},
+		{
+			name:      "valid command - xfrm state list with abbreviated list",
+			ipCommand: "xfrm state l",
+			wantError: false,
+		},
+		{
+			name:      "valid command - xfrm policy list with abbreviated list",
+			ipCommand: "xfrm policy l",
+			wantError: false,
+		},
+		{
+			name:      "invalid command - xfrm state get",
+			ipCommand: "xfrm state get",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - xfrm policy get",
+			ipCommand: "xfrm policy get",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - xfrm state add",
+			ipCommand: "xfrm state add",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - xfrm policy add",
+			ipCommand: "xfrm policy add",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - xfrm state delete",
+			ipCommand: "xfrm state delete",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - xfrm policy delete",
+			ipCommand: "xfrm policy delete",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - just xfrm state",
+			ipCommand: "xfrm state",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - just xfrm policy",
+			ipCommand: "xfrm policy",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - just xfrm",
+			ipCommand: "xfrm show",
+			wantError: true,
+		},
+		{
+			name:      "valid command - xfrm state list with trailing spaces",
+			ipCommand: "xfrm state list ",
+			wantError: false,
+		},
+		{
+			name:      "valid command - xfrm policy list with extra spaces",
+			ipCommand: "xfrm  policy  list",
+			wantError: false,
+		},
+		{
+			name:      "invalid command - address list",
+			ipCommand: "address list",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - link list",
+			ipCommand: "link list",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - route list",
+			ipCommand: "route list",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - neighbour list",
+			ipCommand: "neighbour list",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIPCommand(tt.ipCommand)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateIPCommand(%q) error = %v, wantError %v", tt.ipCommand, err, tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/kernel/mcp/iptables.go
+++ b/pkg/kernel/mcp/iptables.go
@@ -1,0 +1,106 @@
+package kernel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/types"
+)
+
+// GetIptables MCP handler for iptables operations.
+// GetIptables retrieves iptables/ip6tables rules from a Kubernetes node.
+// Automatically detects IPv6 and uses ip6tables when needed.
+func (s *MCPServer) GetIptables(ctx context.Context, req *mcp.CallToolRequest, in types.ListIPTablesParams) (*mcp.CallToolResult, types.Result, error) {
+	iptablesCliAvailable, err := s.UtilityExists(ctx, req, in.Node, in.Image, "iptables")
+	if !iptablesCliAvailable {
+		return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: mentioned image does not have iptables utility: %w", err)
+	}
+
+	if err := validateTableName(in.Table); err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: %w", err)
+	}
+	if err := validateIptablesCommand(in.Command); err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: %w", err)
+	}
+	if in.FilterParameters != "" {
+		if err := validateParameters(in.FilterParameters); err != nil {
+			return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: %w", err)
+		}
+	}
+
+	cmd := newCommand(iptablesCommand(in.FilterParameters))
+	// Defaults to 'filter' table when not specified
+	cmd.addIf(in.Table == "", "-t", "filter")
+	cmd.addIfNotEmpty(in.Table, "-t", in.Table)
+	// Defaults to -L (list) when command not specified
+	cmd.addIf(in.Command == "", "-L")
+	cmd.addIfNotEmpty(in.Command, in.Command)
+	// FilterParameters are invalid with -S/--list-rules command
+	cmd.addIf(in.FilterParameters != "" && in.Command != "-S" && in.Command != "--list-rules", strings.Fields(in.FilterParameters)...)
+
+	stdout, err := s.executeCommand(ctx, req, in.Node, in.Image, cmd.build())
+	if err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: %w", err)
+	}
+	stdout = limitOutputLines(stdout, in.MaxLines)
+	return nil, types.Result{Data: stdout}, nil
+}
+
+// iptablesCommand determines whether to use iptables or ip6tables.
+func iptablesCommand(filterParameters string) string {
+	for _, item := range strings.Split(filterParameters, " ") {
+		// Use of ip6tables CLI is required while either --ipv6 or -6 flag is mentioned
+		if item == "--ipv6" || (strings.Contains(item, "-") && strings.Contains(item, "6")) {
+			return "ip6tables"
+		}
+	}
+	return "iptables"
+}
+
+// validateTableName validates iptables table name
+func validateTableName(table string) error {
+	if table == "" {
+		return nil
+	}
+
+	if _, err := strconv.Atoi(table); err == nil {
+		return fmt.Errorf("invalid table name: %s", table)
+	}
+	validTables := map[string]bool{
+		"filter":   true,
+		"nat":      true,
+		"mangle":   true,
+		"raw":      true,
+		"security": true,
+	}
+
+	if !validTables[strings.TrimSpace(table)] {
+		return fmt.Errorf("invalid table name: %s", table)
+	}
+	return nil
+}
+
+// validateIptablesCommand only allow list operation.
+func validateIptablesCommand(command string) error {
+	if command == "" {
+		return nil
+	}
+
+	if _, err := strconv.Atoi(command); err == nil {
+		return fmt.Errorf("invalid iptables command: %s", command)
+	}
+	validCommand := map[string]bool{
+		"-L":           true,
+		"-S":           true,
+		"--list":       true,
+		"--list-rules": true,
+	}
+
+	if !validCommand[strings.TrimSpace(command)] {
+		return fmt.Errorf("invalid iptables command: %s", command)
+	}
+	return nil
+}

--- a/pkg/kernel/mcp/iptables_test.go
+++ b/pkg/kernel/mcp/iptables_test.go
@@ -1,0 +1,264 @@
+package kernel
+
+import (
+	"testing"
+)
+
+func TestValidateTableName(t *testing.T) {
+	tests := []struct {
+		name      string
+		table     string
+		wantError bool
+	}{
+		{
+			name:      "empty string",
+			table:     "",
+			wantError: false,
+		},
+		{
+			name:      "numeric string",
+			table:     "123",
+			wantError: true,
+		},
+		{
+			name:      "valid table - filter",
+			table:     "filter",
+			wantError: false,
+		},
+		{
+			name:      "valid table - nat",
+			table:     "nat",
+			wantError: false,
+		},
+		{
+			name:      "valid table - mangle",
+			table:     "mangle",
+			wantError: false,
+		},
+		{
+			name:      "valid table - raw",
+			table:     "raw",
+			wantError: false,
+		},
+		{
+			name:      "valid table - security",
+			table:     "security",
+			wantError: false,
+		},
+		{
+			name:      "invalid table - random",
+			table:     "random",
+			wantError: true,
+		},
+		{
+			name:      "invalid table - FILTER uppercase",
+			table:     "FILTER",
+			wantError: true,
+		},
+		{
+			name:      "invalid table - with spaces",
+			table:     "filter ",
+			wantError: false,
+		},
+		{
+			name:      "invalid table - custom",
+			table:     "custom_table",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTableName(tt.table)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateTableName(%q) error = %v, wantError %v", tt.table, err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateIptablesCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   string
+		wantError bool
+	}{
+		{
+			name:      "empty string",
+			command:   "",
+			wantError: false,
+		},
+		{
+			name:      "numeric string",
+			command:   "456",
+			wantError: true,
+		},
+		{
+			name:      "valid command - list",
+			command:   "-L",
+			wantError: false,
+		},
+		{
+			name:      "valid command - list rules",
+			command:   "-S",
+			wantError: false,
+		},
+		{
+			name:      "invalid command - append",
+			command:   "-A",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - delete",
+			command:   "-D",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - insert",
+			command:   "-I",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - flush",
+			command:   "-F",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - lowercase l",
+			command:   "-l",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - with spaces",
+			command:   "-L ",
+			wantError: false,
+		},
+		{
+			name:      "invalid command - random",
+			command:   "list",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIptablesCommand(tt.command)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateIptablesCommand(%q) error = %v, wantError %v", tt.command, err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestIptablesCommand(t *testing.T) {
+	tests := []struct {
+		name             string
+		filterParameters string
+		want             string
+	}{
+		{
+			name:             "empty filter parameters",
+			filterParameters: "",
+			want:             "iptables",
+		},
+		{
+			name:             "ipv6 flag --ipv6",
+			filterParameters: "--ipv6",
+			want:             "ip6tables",
+		},
+		{
+			name:             "ipv6 short flag -6",
+			filterParameters: "-6",
+			want:             "ip6tables",
+		},
+		{
+			name:             "ipv6 flag with other parameters",
+			filterParameters: "-p tcp --ipv6 --dport 80",
+			want:             "ip6tables",
+		},
+		{
+			name:             "ipv6 short flag with other parameters",
+			filterParameters: "-p tcp -6 --dport 80",
+			want:             "ip6tables",
+		},
+		{
+			name:             "ipv4 parameters only",
+			filterParameters: "-p tcp --dport 80",
+			want:             "iptables",
+		},
+		{
+			name:             "parameters with number 6 but not ipv6 flag",
+			filterParameters: "--dport 6000",
+			want:             "iptables",
+		},
+		{
+			name:             "flag containing both - and 6",
+			filterParameters: "-p6",
+			want:             "ip6tables",
+		},
+		{
+			name:             "flag containing both - and 6 in middle",
+			filterParameters: "-m6state",
+			want:             "ip6tables",
+		},
+		{
+			name:             "multiple flags with ipv6 at end",
+			filterParameters: "-p tcp -m state --state NEW --ipv6",
+			want:             "ip6tables",
+		},
+		{
+			name:             "multiple flags with -6 at beginning",
+			filterParameters: "-6 -p tcp -m state --state NEW",
+			want:             "ip6tables",
+		},
+		{
+			name:             "protocol number without dash",
+			filterParameters: "-p tcp --sport 6379",
+			want:             "iptables",
+		},
+		{
+			name:             "dash without 6",
+			filterParameters: "-p tcp -m state",
+			want:             "iptables",
+		},
+		{
+			name:             "number 6 without dash",
+			filterParameters: "6",
+			want:             "iptables",
+		},
+		{
+			name:             "chain name with 6",
+			filterParameters: "-A INPUT6",
+			want:             "iptables",
+		},
+		{
+			name:             "ipv6 address in parameter",
+			filterParameters: "-d 2001:db8::1",
+			want:             "iptables",
+		},
+		{
+			name:             "combined short flags with 6",
+			filterParameters: "-t6n",
+			want:             "ip6tables",
+		},
+		{
+			name:             "whitespace variations with ipv6",
+			filterParameters: "  --ipv6  -p tcp  ",
+			want:             "ip6tables",
+		},
+		{
+			name:             "whitespace variations without ipv6",
+			filterParameters: "  -p tcp  --dport 443  ",
+			want:             "iptables",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := iptablesCommand(tt.filterParameters)
+			if got != tt.want {
+				t.Errorf("iptablesCommand(%q) = %v, want %v", tt.filterParameters, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kernel/mcp/mcp.go
+++ b/pkg/kernel/mcp/mcp.go
@@ -1,0 +1,180 @@
+package kernel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+)
+
+// MCPServer provides MCP server functionality for kernel operations.
+type MCPServer struct {
+	k8sMcpServer *kubernetesmcp.MCPServer
+}
+
+// NewMCPServer creates a new MCP server instance
+func NewMCPServer(k8sMcpServer *kubernetesmcp.MCPServer) *MCPServer {
+	return &MCPServer{
+		k8sMcpServer: k8sMcpServer,
+	}
+}
+
+// AddTools registers all kernel-related MCP tools
+func (s *MCPServer) AddTools(server *mcp.Server) {
+	// get-conntrack tool registration
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "get-conntrack",
+			Description: `get-conntrack allows to interact with the connection tracking system of a Kubernetes node.
+			              Use this command to discover a list of all (or a filtered selection of) currently tracked connections.
+Parameters:
+- node (required): Name of the node from where conntrack entries are expected to be extracted
+- image (required): Image to use to create a tty connection to the node using kubectl debug. If the provided image does not contain 'conntrack' CLI then /proc/net/nf_conntrack 
+                    will be parsed to return requested data.
+- command (optional): These options specify the particular operation to perform. These options can only be used if provided image has 'conntrack' utility available.
+					  -L, --dump : List connection tracking table.
+					  -C, --count: Show the table counter.
+					  -S, --stats: Show the in-kernel connection tracking system statistics.
+- filter_parameters (optional): These paramerters are useful to filter certain entries from the whole table:
+                        -s, --src, --orig-src IP_ADDRESS : Match only entries whose source address in the original direction equals to mentioned IP.
+						-d, --dst, --orig-dst IP_ADDRESS : Match only entries whose destination address in the original direction equals to mentioned IP.
+						-p, --proto PROTO                : Specify layer four (TCP, UDP, ...) protocol.
+						--sport, --orig-port-src PORT    : Source port in original direction.
+						--dport, --orig-port-dst PORT    : Destination port in original direction.
+- max_lines (optional): Limit the number of lines in output
+
+Example:
+- node='ovn-control-plane', image='registry.redhat.io/rhel9/support-tools', commands='-L'
+- node='ovn-worker', image='nicolaka/netshoot', filter_parameters='-s 1.2.3.4 -d 5.6.7.8 -p tcp --sport 32000 --dport 10250'
+
+Example output:
+tcp 6 91 ESTABLISHED src=1.2.3.4 dst=5.6.7.8 sport=32000 dport=10250 src=5.6.7.8 dst=1.2.3.4  sport=10250 dport=32000 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=2
+`,
+		}, s.GetConntrack)
+	// get-iptables tool registration
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "get-iptables",
+			Description: `get-iptables allows to interact with kernel to list packet filter rules.
+			              Iptables and ip6tables are used to inspect the tables of IPv4 and IPv6 packet filter rules in the Linux kernel.
+Parameters:
+- node (required): Name of the node from where packet filter rules are expected to be extracted
+- image (required): Image to use to create a tty connection to the node using kubectl debug. If the provided image does not contain 'iptables' or 'ip6tables' CLI then no output can be expected.
+- table (optional): There are currently five independent tables (which tables are present at any time depends on the kernel configuration options and which modules are present).
+                    filter	: This is the default table
+					nat   	: This  table is consulted when a packet that creates a new connection is encountered.
+					mangle	: This table is used for specialized packet alteration.
+					raw   	: This table is used mainly for configuring exemptions from connection tracking in combination with the NOTRACK target.
+					security: This table is used for Mandatory Access Control (MAC) networking rules.
+- command (required): These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below.
+					  -L, --list [chain]       : List all rules in the selected chain. If no chain is selected, all chains are listed.
+					  -S, --list-rules [chain] : Print all rules in the selected chain. If no chain is selected, all chains are printed like iptables-save.
+- filter_parameters (optional): These paramerters are useful to filter certain entries from the whole table:
+                                -s, --source address[/mask]      : Source specification. Address can be either a network name, a hostname, a network IP address (with /mask), or a  plain  IP  address.
+								-d, --destination address[/mask] : Destination  specification.
+								-v, --verbose					 : Verbose output.
+								-n, --numeric                    : Numeric  output.   IP  addresses  and port numbers will be printed in numeric format.
+								-p, --protocol protocol          : The protocol of the rule or of the packet to check.
+								-4, --ipv4                       : IPv4
+								-6, --ipv6                       : IPv6
+- max_lines (optional): Limit the number of lines in output
+							
+Example:
+- node='ovn-control-plane', image='registry.redhat.io/rhel9/support-tools', table='nat' command='-L', filter_parameters='-nv4'	
+Example output:
+Chain POSTROUTING (policy ACCEPT 675K packets, 41M bytes)
+ pkts bytes target     prot opt in     out     source               destination         
+ 675K   41M OVN-KUBE-EGRESS-IP-MULTI-NIC  all  --  *      *       0.0.0.0/0            0.0.0.0/0     							
+`,
+		}, s.GetIptables)
+	// get-nft tool registration
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "get-nft",
+			Description: `get-nft allows to interact with kernel to list packet filtering and classification rules.
+Parameters:
+- node (required): Name of the node from where packet filtering and classification rules are expected to be extracted
+- image (required): Image to use to create a tty connection to the node using kubectl debug. If the provided image does not contain 'nft' CLI then no output can be expected.
+- command (required): These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below.
+                    - list ruleset   : The ruleset keyword is used to identify the whole set of tables, chains, etc. Print the ruleset in human-readable format.
+					- list tables    : List all chains and rules of the specified table.
+					- list chains    : List all rules of the specified chain.
+					- list sets      : Display the elements in the specified set.
+					- list maps      : Display the elements in the specified map.
+					- list flowtables: List all flowtables.
+- address_families (optional): Address families determine the type of packets which are processed. For each address family, the kernel contains so called hooks at specific stages of
+       						   the packet processing paths, which invoke nftables if rules for these hooks exist.
+							   - ip       IPv4 address family.
+                               - ip6      IPv6 address family.
+                               - inet     Internet (IPv4/IPv6) address family.
+                               - arp      ARP address family, handling IPv4 ARP packets.
+                               - bridge   Bridge address family, handling packets which traverse a bridge device.
+                               - netdev   Netdev address family, handling packets on ingress and egress.
+- max_lines (optional): Limit the number of lines in output
+					
+Example:
+- node='ovn-control-plane', image='registry.redhat.io/rhel9/support-tools', command='list tables', address_families='inet'
+Example output:
+table inet ovn-kubernetes
+				`,
+		}, s.GetNFT)
+	// get-ip tool registration
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "get-ip",
+			Description: `get-ip allows to interact with kernel to list routing, network devices, interfaces.
+Parameters:
+- node (required): Name of the node on which ip command is expected to be executed
+- image (required): Image to use to create a tty connection to the node using kubectl debug. If the provided image does not contain 'ip' CLI then no output can be expected.
+- options (optional): These options helps in providing more details or formattig output data.
+                      -d, -details        : Output more detailed information.
+					  -4                  : shortcut for -family inet.
+					  -6                  : shortcut for -family inet6.
+					  -r, -resolve        : use the system's name resolver to print DNS names instead of host addresses.
+					  -n, -netns <NETNS>  : switches ip to the specified network namespace NETNS.
+					  -a, -all            : executes specified command over all objects, it depends if command supports this option.
+- command (required): These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below.
+                      - address show     : protocol (IP or IPv6) address on a device.
+					  - link show        : network device.
+					  - neighbour show   : manage ARP or NDISC cache entries.
+					  - netns show       : manage network namespaces.
+					  - route show       : routing table entry.
+					  - rule show        : rule in routing policy database.
+					  - vrf show         : manage virtual routing and forwarding devices. 
+					  - xfrm state list  : show Security Association Database.
+					  - xfrm policy list : show Security Policy Database.
+- filter_parameters (optional): This allows to mention sub command to get more filtered data. Available sub command varries and supportability depends on what is 
+                          already supported with 'ip' utility.
+- max_lines (optional): Limit the number of lines in output
+
+Example:
+- node='ovn-control-plane', image='registry.redhat.io/rhel9/support-tools', options="-4", command='route show', filter_parameters='table all'
+Example output:
+default via 10.0.0.254 dev br-ex proto dhcp src 10.0.0.10 metric 48 				`,
+		}, s.GetIPCommandOutput)
+}
+
+// executeCommand executes a command on a node via kubectl debug
+func (s *MCPServer) executeCommand(ctx context.Context, req *mcp.CallToolRequest, node, image string, command []string) (string, error) {
+	chrootCommand := append([]string{"chroot", "/host"}, command...)
+	debugParameter := k8stypes.DebugNodeParams{Name: node, Image: image, Command: chrootCommand}
+	_, result, err := s.k8sMcpServer.DebugNode(ctx, req, debugParameter)
+	if err != nil {
+		return "", fmt.Errorf("error while establishing tty connection to the node: %w", err)
+	}
+
+	// Filter out warning lines from stderr
+	if result.Stderr != "" {
+		stderr := filterWarnings(result.Stderr)
+		if stderr != "" {
+			return "", fmt.Errorf("error while running command: %s", stderr)
+		}
+	}
+
+	// Filter out warning lines from stdout
+	stdout := filterWarnings(result.Stdout)
+
+	return stdout, nil
+}

--- a/pkg/kernel/mcp/nft.go
+++ b/pkg/kernel/mcp/nft.go
@@ -1,0 +1,82 @@
+package kernel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/types"
+)
+
+// GetNFT MCP handler for nftables operations.
+// GetNFT retrieves nftables configuration from a Kubernetes node.
+func (s *MCPServer) GetNFT(ctx context.Context, req *mcp.CallToolRequest, in types.ListNFTParams) (*mcp.CallToolResult, types.Result, error) {
+	nftCliAvailable, err := s.UtilityExists(ctx, req, in.Node, in.Image, "nft")
+	if !nftCliAvailable {
+		return nil, types.Result{}, fmt.Errorf("error while getting nft data: mentioned image does not have nft utility: %w", err)
+	}
+
+	if err := validateNFTCommand(in.Command); err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting nft data: %w", err)
+	}
+	if err := validateNFTAddressFamily(in.AddressFamilies); err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting nft data: %w", err)
+	}
+
+	cmd := newCommand("nft")
+	cmd.add(strings.Fields(in.Command)...)
+	cmd.addIf(in.AddressFamilies != "", in.AddressFamilies)
+
+	stdout, err := s.executeCommand(ctx, req, in.Node, in.Image, cmd.build())
+	if err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting nft data: %w", err)
+	}
+	stdout = limitOutputLines(stdout, in.MaxLines)
+	return nil, types.Result{Data: stdout}, nil
+}
+
+// validateNFTCommand validates nftables command. This is to put a limitation on the use of the tool.
+func validateNFTCommand(command string) error {
+	if _, err := strconv.Atoi(command); err == nil {
+		return fmt.Errorf("invalid nft command: %s", command)
+	}
+	validCommand := map[string]bool{
+		"list ruleset":    true,
+		"list tables":     true,
+		"list chains":     true,
+		"list sets":       true,
+		"list maps":       true,
+		"list flowtables": true,
+	}
+
+	if !validCommand[strings.TrimSpace(command)] {
+		return fmt.Errorf("invalid nft command: %s", command)
+	}
+	return nil
+}
+
+// validateNFTAddressFamily validates nftables address family.
+func validateNFTAddressFamily(addrFamily string) error {
+	if addrFamily == "" {
+		return nil
+	}
+
+	if _, err := strconv.Atoi(addrFamily); err == nil {
+		return fmt.Errorf("invalid nft address family: %s", addrFamily)
+	}
+	validaddrFamily := map[string]bool{
+		"ip":     true,
+		"ip6":    true,
+		"inet":   true,
+		"arp":    true,
+		"bridge": true,
+		"netdev": true,
+	}
+
+	if !validaddrFamily[strings.TrimSpace(addrFamily)] {
+		return fmt.Errorf("invalid nft address family: %s", addrFamily)
+	}
+	return nil
+}

--- a/pkg/kernel/mcp/nft_test.go
+++ b/pkg/kernel/mcp/nft_test.go
@@ -1,0 +1,176 @@
+package kernel
+
+import (
+	"testing"
+)
+
+func TestValidateNFTCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   string
+		wantError bool
+	}{
+		{
+			name:      "empty string",
+			command:   "",
+			wantError: true,
+		},
+		{
+			name:      "numeric string",
+			command:   "789",
+			wantError: true,
+		},
+		{
+			name:      "valid command - list ruleset",
+			command:   "list ruleset",
+			wantError: false,
+		},
+		{
+			name:      "valid command - list tables",
+			command:   "list tables",
+			wantError: false,
+		},
+		{
+			name:      "valid command - list chains",
+			command:   "list chains",
+			wantError: false,
+		},
+		{
+			name:      "valid command - list sets",
+			command:   "list sets",
+			wantError: false,
+		},
+		{
+			name:      "valid command - list maps",
+			command:   "list maps",
+			wantError: false,
+		},
+		{
+			name:      "valid command - list flowtables",
+			command:   "list flowtables",
+			wantError: false,
+		},
+		{
+			name:      "invalid command - add",
+			command:   "add table",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - delete",
+			command:   "delete table",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - flush",
+			command:   "flush ruleset",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - list only",
+			command:   "list",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - extra spaces",
+			command:   "list  ruleset",
+			wantError: true,
+		},
+		{
+			name:      "invalid command - uppercase",
+			command:   "LIST RULESET",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNFTCommand(tt.command)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateNFTCommand(%q) error = %v, wantError %v", tt.command, err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateNFTAddressFamily(t *testing.T) {
+	tests := []struct {
+		name       string
+		addrFamily string
+		wantError  bool
+	}{
+		{
+			name:       "empty string",
+			addrFamily: "",
+			wantError:  false,
+		},
+		{
+			name:       "numeric string",
+			addrFamily: "101",
+			wantError:  true,
+		},
+		{
+			name:       "valid family - ip",
+			addrFamily: "ip",
+			wantError:  false,
+		},
+		{
+			name:       "valid family - ip6",
+			addrFamily: "ip6",
+			wantError:  false,
+		},
+		{
+			name:       "valid family - inet",
+			addrFamily: "inet",
+			wantError:  false,
+		},
+		{
+			name:       "valid family - arp",
+			addrFamily: "arp",
+			wantError:  false,
+		},
+		{
+			name:       "valid family - bridge",
+			addrFamily: "bridge",
+			wantError:  false,
+		},
+		{
+			name:       "valid family - netdev",
+			addrFamily: "netdev",
+			wantError:  false,
+		},
+		{
+			name:       "invalid family - ipv4",
+			addrFamily: "ipv4",
+			wantError:  true,
+		},
+		{
+			name:       "invalid family - ipv6",
+			addrFamily: "ipv6",
+			wantError:  true,
+		},
+		{
+			name:       "invalid family - uppercase",
+			addrFamily: "IP",
+			wantError:  true,
+		},
+		{
+			name:       "invalid family - with spaces",
+			addrFamily: "ip ",
+			wantError:  false,
+		},
+		{
+			name:       "invalid family - random",
+			addrFamily: "random",
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNFTAddressFamily(tt.addrFamily)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateNFTAddressFamily(%q) error = %v, wantError %v", tt.addrFamily, err, tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/kernel/mcp/util.go
+++ b/pkg/kernel/mcp/util.go
@@ -1,0 +1,115 @@
+package kernel
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+)
+
+const (
+	// MaxOutputLines defines the maximum number of lines to return from command output
+	MaxOutputLines = 100
+)
+
+// commandBuilder helps build commands with a fluent interface
+type commandBuilder struct {
+	args []string
+}
+
+// newCommand creates a new command builder with the base command
+func newCommand(baseCmd ...string) *commandBuilder {
+	return &commandBuilder{args: baseCmd}
+}
+
+// add adds arguments to the command
+func (cb *commandBuilder) add(args ...string) *commandBuilder {
+	cb.args = append(cb.args, args...)
+	return cb
+}
+
+// addIf adds arguments to the command only if the condition is true
+func (cb *commandBuilder) addIf(condition bool, args ...string) *commandBuilder {
+	if condition {
+		cb.args = append(cb.args, args...)
+	}
+	return cb
+}
+
+// addIfNotEmpty adds arguments to the command only if the value is not empty
+func (cb *commandBuilder) addIfNotEmpty(value string, args ...string) *commandBuilder {
+	if value != "" {
+		cb.args = append(cb.args, args...)
+	}
+	return cb
+}
+
+// build returns the final command slice
+func (cb *commandBuilder) build() []string {
+	return cb.args
+}
+
+// UtilityExists checks if a utility/command exists in the container
+func (s *MCPServer) UtilityExists(ctx context.Context, req *mcp.CallToolRequest, node, image, utility string) (bool, error) {
+	cmd := newCommand("chroot", "/host", utility, "-V")
+	debugParameter := k8stypes.DebugNodeParams{Name: node, Image: image, Command: cmd.build()}
+	_, result, err := s.k8sMcpServer.DebugNode(ctx, req, debugParameter)
+	if err != nil || filterWarnings(result.Stderr) != "" {
+		return false, fmt.Errorf("error while checking availability of the utility %s: %s : %w", utility, filterWarnings(result.Stderr), err)
+	}
+	return true, nil
+}
+
+// filterWarnings filters out lines starting with "Warning" from the output
+func filterWarnings(output string) string {
+	if output == "" {
+		return output
+	}
+
+	lines := strings.Split(output, "\n")
+	var filteredLines []string
+
+	for _, line := range lines {
+		if !strings.Contains(line, "Warning") && !strings.Contains(line, "warning") && !strings.Contains(line, "WARNING") {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+
+	return strings.Join(filteredLines, "\n")
+}
+
+// limitOutputLines limits the output to a maximum number of lines.
+// If the output exceeds the maximum, it truncates and adds a message indicating truncation.
+func limitOutputLines(output string, maxLines int) string {
+	if output == "" {
+		return output
+	}
+	if maxLines <= 0 {
+		maxLines = MaxOutputLines
+	}
+
+	lines := strings.Split(output, "\n")
+	if len(lines) <= maxLines {
+		return output
+	}
+
+	// Truncate to maxLines and add a truncation message
+	truncatedLines := lines[:maxLines]
+	truncatedLines = append(truncatedLines, fmt.Sprintf("\n... Output truncated. Showing first %d lines out of %d total lines.", maxLines, len(lines)))
+
+	return strings.Join(truncatedLines, "\n")
+}
+
+// validateParameters validates whether any parameter contains shell
+// metacharacters or not. It returns an error if there are any.
+func validateParameters(param string) error {
+	shellMetacharacters := regexp.MustCompile(`[;&|$` + "`" + `<>\\()]`)
+	if shellMetacharacters.MatchString(param) {
+		return fmt.Errorf("invalid use of metacharacters in parameter: %s", param)
+	}
+
+	return nil
+}

--- a/pkg/kernel/mcp/util_test.go
+++ b/pkg/kernel/mcp/util_test.go
@@ -1,0 +1,780 @@
+package kernel
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFilterWarnings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single line without warning",
+			input:    "This is a normal line",
+			expected: "This is a normal line",
+		},
+		{
+			name:     "single line with Warning at start",
+			input:    "Warning: something happened",
+			expected: "",
+		},
+		{
+			name:     "single line with Warning in middle",
+			input:    "Error: Warning detected in system",
+			expected: "",
+		},
+		{
+			name:     "single line with lowercase warning",
+			input:    "This is a warning message",
+			expected: "",
+		},
+		{
+			name:     "multiple lines without warnings",
+			input:    "Line 1\nLine 2\nLine 3",
+			expected: "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "multiple lines with one warning",
+			input:    "Line 1\nWarning: something wrong\nLine 3",
+			expected: "Line 1\nLine 3",
+		},
+		{
+			name:     "multiple lines with multiple warnings",
+			input:    "Line 1\nWarning: first warning\nLine 3\nWarning: second warning\nLine 5",
+			expected: "Line 1\nLine 3\nLine 5",
+		},
+		{
+			name:     "line with Warning substring",
+			input:    "ReWarning test\nWarningLevel\nLine without",
+			expected: "Line without",
+		},
+		{
+			name:     "empty lines mixed with warnings",
+			input:    "\nWarning: test\n\nNormal line\n",
+			expected: "\n\nNormal line\n",
+		},
+		{
+			name:     "warning with special characters",
+			input:    "Warning: file.txt not found!\nProcessed successfully",
+			expected: "Processed successfully",
+		},
+		{
+			name:     "case sensitive - warning vs Warning vs WARNING",
+			input:    "warning: lowercase\nWarning: uppercase\nWARNING: all caps",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterWarnings(tt.input)
+			if result != tt.expected {
+				t.Errorf("filterWarnings() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateParameters(t *testing.T) {
+	tests := []struct {
+		name      string
+		param     string
+		wantError bool
+	}{
+		{
+			name:      "empty string",
+			param:     "",
+			wantError: false,
+		},
+		{
+			name:      "valid with hyphens",
+			param:     "--param",
+			wantError: false,
+		},
+		{
+			name:      "valid with equals",
+			param:     "key=value",
+			wantError: false,
+		},
+		{
+			name:      "valid with spaces",
+			param:     "hello world",
+			wantError: false,
+		},
+		{
+			name:      "invalid with semicolon",
+			param:     "test;rm -rf",
+			wantError: true,
+		},
+		{
+			name:      "invalid with ampersand",
+			param:     "test&background",
+			wantError: true,
+		},
+		{
+			name:      "invalid with pipe",
+			param:     "test|grep",
+			wantError: true,
+		},
+		{
+			name:      "invalid with dollar sign",
+			param:     "test$var",
+			wantError: true,
+		},
+		{
+			name:      "invalid with backtick",
+			param:     "test`whoami`",
+			wantError: true,
+		},
+		{
+			name:      "invalid with less than",
+			param:     "test<input",
+			wantError: true,
+		},
+		{
+			name:      "invalid with greater than",
+			param:     "test>output",
+			wantError: true,
+		},
+		{
+			name:      "invalid with backslash",
+			param:     "test\\escape",
+			wantError: true,
+		},
+		{
+			name:      "invalid with opening parenthesis",
+			param:     "test(subshell",
+			wantError: true,
+		},
+		{
+			name:      "invalid with closing parenthesis",
+			param:     "test)subshell",
+			wantError: true,
+		},
+		{
+			name:      "invalid with multiple metacharacters",
+			param:     "test;ls|grep&",
+			wantError: true,
+		},
+		{
+			name:      "invalid with semicolon only",
+			param:     ";",
+			wantError: true,
+		},
+		{
+			name:      "invalid with command substitution",
+			param:     "$(whoami)",
+			wantError: true,
+		},
+		{
+			name:      "invalid with backtick command substitution",
+			param:     "`id`",
+			wantError: true,
+		},
+		{
+			name:      "valid IP address",
+			param:     "192.168.1.1",
+			wantError: false,
+		},
+		{
+			name:      "valid CIDR notation",
+			param:     "10.0.0.0/24",
+			wantError: false,
+		},
+		{
+			name:      "valid with port number",
+			param:     "127.0.0.1:8080",
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateParameters(tt.param)
+			if tt.wantError && err == nil {
+				t.Errorf("validateParameters(%q) expected error, got nil", tt.param)
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("validateParameters(%q) expected no error, got %v", tt.param, err)
+			}
+		})
+	}
+}
+
+func TestLimitOutputLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxLines int
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			maxLines: 10,
+			expected: "",
+		},
+		{
+			name:     "single line within limit",
+			input:    "This is a single line",
+			maxLines: 10,
+			expected: "This is a single line",
+		},
+		{
+			name:     "multiple lines within limit",
+			input:    "Line 1\nLine 2\nLine 3",
+			maxLines: 5,
+			expected: "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "exactly at limit",
+			input:    "Line 1\nLine 2\nLine 3",
+			maxLines: 3,
+			expected: "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "exceeds limit - simple case",
+			input:    "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+			maxLines: 3,
+			expected: "Line 1\nLine 2\nLine 3\n\n... Output truncated. Showing first 3 lines out of 5 total lines.",
+		},
+		{
+			name:     "exceeds limit by one",
+			input:    "Line 1\nLine 2\nLine 3\nLine 4",
+			maxLines: 3,
+			expected: "Line 1\nLine 2\nLine 3\n\n... Output truncated. Showing first 3 lines out of 4 total lines.",
+		},
+		{
+			name:     "exceeds limit by many",
+			input:    "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10",
+			maxLines: 2,
+			expected: "Line 1\nLine 2\n\n... Output truncated. Showing first 2 lines out of 10 total lines.",
+		},
+		{
+			name:     "maxLines is zero - uses default MaxOutputLines",
+			input:    "Line 1\nLine 2",
+			maxLines: 0,
+			expected: "Line 1\nLine 2",
+		},
+		{
+			name:     "maxLines is negative - uses default MaxOutputLines",
+			input:    "Line 1\nLine 2",
+			maxLines: -5,
+			expected: "Line 1\nLine 2",
+		},
+		{
+			name:     "maxLines is 1",
+			input:    "Line 1\nLine 2\nLine 3",
+			maxLines: 1,
+			expected: "Line 1\n\n... Output truncated. Showing first 1 lines out of 3 total lines.",
+		},
+		{
+			name:     "empty lines included in count",
+			input:    "Line 1\n\nLine 3\n\nLine 5",
+			maxLines: 3,
+			expected: "Line 1\n\nLine 3\n\n... Output truncated. Showing first 3 lines out of 5 total lines.",
+		},
+		{
+			name:     "lines with special characters",
+			input:    "Line 1 with $special\nLine 2 with &chars\nLine 3 with |pipes\nLine 4",
+			maxLines: 2,
+			expected: "Line 1 with $special\nLine 2 with &chars\n\n... Output truncated. Showing first 2 lines out of 4 total lines.",
+		},
+		{
+			name:     "lines with tabs and spaces",
+			input:    "\tTabbed line\n    Spaced line\nNormal line\nAnother line",
+			maxLines: 2,
+			expected: "\tTabbed line\n    Spaced line\n\n... Output truncated. Showing first 2 lines out of 4 total lines.",
+		},
+		{
+			name:     "very long single line",
+			input:    "This is a very long line that contains lots of text and should still be treated as a single line",
+			maxLines: 5,
+			expected: "This is a very long line that contains lots of text and should still be treated as a single line",
+		},
+		{
+			name:     "trailing newline preserved when within limit",
+			input:    "Line 1\nLine 2\n",
+			maxLines: 3,
+			expected: "Line 1\nLine 2\n",
+		},
+		{
+			name:     "trailing newline counts as extra line",
+			input:    "Line 1\nLine 2\n",
+			maxLines: 2,
+			expected: "Line 1\nLine 2\n\n... Output truncated. Showing first 2 lines out of 3 total lines.",
+		},
+		{
+			name:     "mixed content types",
+			input:    "Header\nData: value1\nData: value2\nData: value3\nData: value4\nFooter",
+			maxLines: 4,
+			expected: "Header\nData: value1\nData: value2\nData: value3\n\n... Output truncated. Showing first 4 lines out of 6 total lines.",
+		},
+		{
+			name:     "unicode characters",
+			input:    "行1\n行2\n行3\n行4\n行5",
+			maxLines: 3,
+			expected: "行1\n行2\n行3\n\n... Output truncated. Showing first 3 lines out of 5 total lines.",
+		},
+		{
+			name:     "large output with default limit",
+			input:    generateLargeOutput(150),
+			maxLines: 0, // Should use MaxOutputLines (100)
+			expected: generateLargeOutput(100) + "\n\n... Output truncated. Showing first 100 lines out of 150 total lines.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := limitOutputLines(tt.input, tt.maxLines)
+			if result != tt.expected {
+				t.Errorf("limitOutputLines() =\n%q\nwant\n%q", result, tt.expected)
+			}
+		})
+	}
+}
+
+// generateLargeOutput generates n lines of output for testing
+func generateLargeOutput(n int) string {
+	var lines []string
+	for i := 0; i < n; i++ {
+		lines = append(lines, fmt.Sprintf("Line %d", i+1))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestNewCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseCmd  []string
+		expected []string
+	}{
+		{
+			name:     "single base command",
+			baseCmd:  []string{"ls"},
+			expected: []string{"ls"},
+		},
+		{
+			name:     "multiple base commands",
+			baseCmd:  []string{"chroot", "/host", "iptables"},
+			expected: []string{"chroot", "/host", "iptables"},
+		},
+		{
+			name:     "empty base command",
+			baseCmd:  []string{},
+			expected: []string{},
+		},
+		{
+			name:     "command with flags",
+			baseCmd:  []string{"ip", "route"},
+			expected: []string{"ip", "route"},
+		},
+		{
+			name:     "nil base command",
+			baseCmd:  nil,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newCommand(tt.baseCmd...)
+			result := cb.build()
+			if !slices.Equal(result, tt.expected) {
+				t.Errorf("newCommand(%v).build() = %v, want %v", tt.baseCmd, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommandBuilder_Add(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseCmd  []string
+		addArgs  [][]string
+		expected []string
+	}{
+		{
+			name:     "add single argument",
+			baseCmd:  []string{"ls"},
+			addArgs:  [][]string{{"-l"}},
+			expected: []string{"ls", "-l"},
+		},
+		{
+			name:     "add multiple arguments at once",
+			baseCmd:  []string{"ls"},
+			addArgs:  [][]string{{"-l", "-a", "-h"}},
+			expected: []string{"ls", "-l", "-a", "-h"},
+		},
+		{
+			name:     "add arguments in multiple calls",
+			baseCmd:  []string{"ip"},
+			addArgs:  [][]string{{"route"}, {"show"}},
+			expected: []string{"ip", "route", "show"},
+		},
+		{
+			name:     "add empty arguments",
+			baseCmd:  []string{"ls"},
+			addArgs:  [][]string{{}},
+			expected: []string{"ls"},
+		},
+		{
+			name:     "add to empty base command",
+			baseCmd:  []string{},
+			addArgs:  [][]string{{"ls", "-l"}},
+			expected: []string{"ls", "-l"},
+		},
+		{
+			name:     "chain multiple add calls",
+			baseCmd:  []string{"iptables"},
+			addArgs:  [][]string{{"-t", "filter"}, {"-L"}, {"INPUT"}},
+			expected: []string{"iptables", "-t", "filter", "-L", "INPUT"},
+		},
+		{
+			name:     "add arguments with special characters",
+			baseCmd:  []string{"grep"},
+			addArgs:  [][]string{{"--include=*.go"}, {"pattern"}},
+			expected: []string{"grep", "--include=*.go", "pattern"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newCommand(tt.baseCmd...)
+			for _, args := range tt.addArgs {
+				cb.add(args...)
+			}
+			result := cb.build()
+			if !slices.Equal(result, tt.expected) {
+				t.Errorf("add() chain result = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommandBuilder_AddIf(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseCmd   []string
+		condition bool
+		args      []string
+		expected  []string
+	}{
+		{
+			name:      "condition true - adds arguments",
+			baseCmd:   []string{"ls"},
+			condition: true,
+			args:      []string{"-l", "-a"},
+			expected:  []string{"ls", "-l", "-a"},
+		},
+		{
+			name:      "condition false - does not add arguments",
+			baseCmd:   []string{"ls"},
+			condition: false,
+			args:      []string{"-l", "-a"},
+			expected:  []string{"ls"},
+		},
+		{
+			name:      "condition true with empty args",
+			baseCmd:   []string{"ls"},
+			condition: true,
+			args:      []string{},
+			expected:  []string{"ls"},
+		},
+		{
+			name:      "condition false with empty args",
+			baseCmd:   []string{"ls"},
+			condition: false,
+			args:      []string{},
+			expected:  []string{"ls"},
+		},
+		{
+			name:      "condition true with single arg",
+			baseCmd:   []string{"ip"},
+			condition: true,
+			args:      []string{"-6"},
+			expected:  []string{"ip", "-6"},
+		},
+		{
+			name:      "condition false with single arg",
+			baseCmd:   []string{"ip"},
+			condition: false,
+			args:      []string{"-6"},
+			expected:  []string{"ip"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newCommand(tt.baseCmd...)
+			cb.addIf(tt.condition, tt.args...)
+			result := cb.build()
+			if !slices.Equal(result, tt.expected) {
+				t.Errorf("addIf(%v, %v) = %v, want %v", tt.condition, tt.args, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommandBuilder_AddIfNotEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseCmd  []string
+		value    string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "non-empty value - adds arguments",
+			baseCmd:  []string{"iptables"},
+			value:    "filter",
+			args:     []string{"-t", "filter"},
+			expected: []string{"iptables", "-t", "filter"},
+		},
+		{
+			name:     "empty value - does not add arguments",
+			baseCmd:  []string{"iptables"},
+			value:    "",
+			args:     []string{"-t", "filter"},
+			expected: []string{"iptables"},
+		},
+		{
+			name:     "whitespace only value - adds arguments",
+			baseCmd:  []string{"iptables"},
+			value:    "   ",
+			args:     []string{"-t", "nat"},
+			expected: []string{"iptables", "-t", "nat"},
+		},
+		{
+			name:     "non-empty value with empty args",
+			baseCmd:  []string{"ls"},
+			value:    "test",
+			args:     []string{},
+			expected: []string{"ls"},
+		},
+		{
+			name:     "empty value with empty args",
+			baseCmd:  []string{"ls"},
+			value:    "",
+			args:     []string{},
+			expected: []string{"ls"},
+		},
+		{
+			name:     "non-empty value with single arg",
+			baseCmd:  []string{"ip"},
+			value:    "show",
+			args:     []string{"route"},
+			expected: []string{"ip", "route"},
+		},
+		{
+			name:     "non-empty value with multiple args",
+			baseCmd:  []string{"ip"},
+			value:    "192.168.1.1",
+			args:     []string{"-d", "192.168.1.1"},
+			expected: []string{"ip", "-d", "192.168.1.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newCommand(tt.baseCmd...)
+			cb.addIfNotEmpty(tt.value, tt.args...)
+			result := cb.build()
+			if !slices.Equal(result, tt.expected) {
+				t.Errorf("addIfNotEmpty(%q, %v) = %v, want %v", tt.value, tt.args, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommandBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name     string
+		builder  func() *commandBuilder
+		expected []string
+	}{
+		{
+			name: "simple command",
+			builder: func() *commandBuilder {
+				return newCommand("ls")
+			},
+			expected: []string{"ls"},
+		},
+		{
+			name: "command built with add",
+			builder: func() *commandBuilder {
+				return newCommand("ls").add("-l", "-a")
+			},
+			expected: []string{"ls", "-l", "-a"},
+		},
+		{
+			name: "command built with addIf true",
+			builder: func() *commandBuilder {
+				return newCommand("ls").addIf(true, "-l")
+			},
+			expected: []string{"ls", "-l"},
+		},
+		{
+			name: "command built with addIf false",
+			builder: func() *commandBuilder {
+				return newCommand("ls").addIf(false, "-l")
+			},
+			expected: []string{"ls"},
+		},
+		{
+			name: "command built with addIfNotEmpty non-empty",
+			builder: func() *commandBuilder {
+				return newCommand("ls").addIfNotEmpty("value", "-l")
+			},
+			expected: []string{"ls", "-l"},
+		},
+		{
+			name: "command built with addIfNotEmpty empty",
+			builder: func() *commandBuilder {
+				return newCommand("ls").addIfNotEmpty("", "-l")
+			},
+			expected: []string{"ls"},
+		},
+		{
+			name: "empty command",
+			builder: func() *commandBuilder {
+				return newCommand()
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.builder().build()
+			if !slices.Equal(result, tt.expected) {
+				t.Errorf("build() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommandBuilder_ChainedCalls(t *testing.T) {
+	tests := []struct {
+		name     string
+		builder  func() *commandBuilder
+		expected []string
+	}{
+		{
+			name: "chain add, addIf, addIfNotEmpty",
+			builder: func() *commandBuilder {
+				return newCommand("iptables").
+					add("-t", "filter").
+					addIf(true, "-L").
+					addIfNotEmpty("INPUT", "INPUT")
+			},
+			expected: []string{"iptables", "-t", "filter", "-L", "INPUT"},
+		},
+		{
+			name: "chain with mixed conditions",
+			builder: func() *commandBuilder {
+				return newCommand("ip").
+					addIf(true, "route").
+					addIf(false, "link").
+					add("show").
+					addIfNotEmpty("", "default").
+					addIfNotEmpty("table", "table", "main")
+			},
+			expected: []string{"ip", "route", "show", "table", "main"},
+		},
+		{
+			name: "real world iptables example",
+			builder: func() *commandBuilder {
+				table := "nat"
+				command := "-L"
+				filterParams := "-n -v"
+				return newCommand("iptables").
+					addIf(table == "", "-t", "filter").
+					addIfNotEmpty(table, "-t", table).
+					addIf(command == "", "-L").
+					addIfNotEmpty(command, command).
+					addIfNotEmpty(filterParams, "-n", "-v")
+			},
+			expected: []string{"iptables", "-t", "nat", "-L", "-n", "-v"},
+		},
+		{
+			name: "complex chaining with all methods",
+			builder: func() *commandBuilder {
+				return newCommand("chroot", "/host").
+					add("iptables").
+					addIf(true, "-t").
+					add("filter").
+					addIfNotEmpty("INPUT", "-L", "INPUT").
+					addIf(false, "-S").
+					add("-n")
+			},
+			expected: []string{"chroot", "/host", "iptables", "-t", "filter", "-L", "INPUT", "-n"},
+		},
+		{
+			name: "multiple build calls return same result",
+			builder: func() *commandBuilder {
+				cb := newCommand("ls").add("-l")
+				cb.build()
+				cb.build()
+				return cb
+			},
+			expected: []string{"ls", "-l"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.builder().build()
+			if !slices.Equal(result, tt.expected) {
+				t.Errorf("chained build() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommandBuilder_Immutability(t *testing.T) {
+	t.Run("build does not modify builder", func(t *testing.T) {
+		cb := newCommand("ls").add("-l")
+		result1 := cb.build()
+		result2 := cb.build()
+
+		if !slices.Equal(result1, result2) {
+			t.Errorf("multiple build() calls returned different results: %v vs %v", result1, result2)
+		}
+	})
+
+	t.Run("modifying returned slice affects builder - no defensive copy", func(t *testing.T) {
+		cb := newCommand("ls").add("-l")
+		result1 := cb.build()
+		result1[0] = "modified"
+		result2 := cb.build()
+
+		// Note: The current implementation returns the internal slice directly
+		// without making a defensive copy, so modifications affect the builder
+		if result2[0] != "modified" {
+			t.Errorf("expected modification to affect builder, but it didn't")
+		}
+	})
+
+	t.Run("continue building after build call", func(t *testing.T) {
+		cb := newCommand("ls")
+		cb.build()
+		cb.add("-l")
+		result := cb.build()
+
+		expected := []string{"ls", "-l"}
+		if !slices.Equal(result, expected) {
+			t.Errorf("build after modification = %v, want %v", result, expected)
+		}
+	})
+}

--- a/pkg/kernel/types/types.go
+++ b/pkg/kernel/types/types.go
@@ -1,0 +1,49 @@
+package types
+
+// CommonParams contains the common parameters required for executing kernel commands on a Kubernetes node.
+// These parameters are embedded in other specific parameter types.
+type CommonParams struct {
+	Node     string `json:"node"`                // Node is the name of the Kubernetes node where the command will be executed
+	Image    string `json:"image"`               // Image is the container image to use for running the command
+	MaxLines int    `json:"max_lines,omitempty"` // Limit the number of lines in output
+}
+
+// ListConntrackParams contains parameters for listing connection tracking entries using conntrack command.
+// Connection tracking entries show active network connections and their state.
+type ListConntrackParams struct {
+	CommonParams
+	Command          string `json:"command,omitempty"`           // Command specifies the conntrack command to execute (e.g., "list", "dump")
+	FilterParameters string `json:"filter_parameters,omitempty"` // FilterParameters specifies additional filter criteria for conntrack entries
+}
+
+// ListIPTablesParams contains parameters for inspecting iptables/ip6tables packet filter rules.
+// Supports both IPv4 (iptables) and IPv6 (ip6tables) firewall rules.
+type ListIPTablesParams struct {
+	CommonParams
+	Table            string `json:"table,omitempty"`             // Table specifies the iptables table to query (e.g., "filter", "nat", "mangle", "raw")
+	Command          string `json:"command"`                     // Command specifies the iptables command to execute (e.g., "iptables", "ip6tables")
+	FilterParameters string `json:"filter_parameters,omitempty"` // FilterParameters specifies additional filter criteria for iptables rules
+}
+
+// ListNFTParams contains parameters for inspecting nftables packet filtering and classification rules.
+// nftables is the modern replacement for iptables in the Linux kernel.
+type ListNFTParams struct {
+	CommonParams
+	Command         string `json:"command"`                    // Command specifies the nft command to execute
+	AddressFamilies string `json:"address_families,omitempty"` // AddressFamilies specifies the address family to filter (e.g., "ip", "ip6", "inet", "arp", "bridge")
+}
+
+// ListIPParams contains parameters for inspecting routing, network devices, and network interfaces.
+// Uses the iproute2 suite (ip command) for network configuration and inspection.
+type ListIPParams struct {
+	CommonParams
+	Options          string `json:"options,omitempty"`           // Options specifies additional command-line options for the ip command
+	Command          string `json:"command"`                     // Command specifies the ip subcommand to execute (e.g., "route", "link", "addr", "neigh")
+	FilterParameters string `json:"filter_parameters,omitempty"` // FilterParameters specifies additional filter criteria for the output
+}
+
+// Result represents the output returned from executing a kernel command.
+// The data contains the command's stdout/stderr output.
+type Result struct {
+	Data string `json:"data"` // Data contains the command execution output
+}


### PR DESCRIPTION
Implements MCP tools for inspecting kernel level networking configurations:
- get-conntrack: retrieves connection tracking entries from a Kubernetes node.
- get-iptables: retrieves iptables/ip6tables rules from a Kubernetes node.
- get-nft: retrieves nftables configuration from a Kubernetes node.
- get-ip: executes 'ip' utility commands on a node.

--> ovn-kubernetes - get-ip (MCP)(node: "worker-2.shrocp4upi420ovn.lab.upshift.rdu2.redhat.com", image: "registry.redhat.io/rhel9/support-tools", command: "route show")
  ⎿ {                                                                                                                                                    
      "data": "default via 10.0.95.254 dev br-ex proto dhcp src 10.0.93.147 metric 48 \n10.0.88.0/21 dev br-ex proto kernel scope link src 10.0.93.147 me
    tric 48 \n10.128.0.0/14 via 10.131.0.1 dev ovn-k8s-mp0 \n10.131.0.0/23 dev ovn-k8s-mp0 proto kernel scope link src 10.131.0.2 \n169.254.0.0/17 dev br
    … +3 lines (ctrl+o to expand)

--> ● ovn-kubernetes - get-nft (MCP)(node: "worker-2.shrocp4upi420ovn.lab.upshift.rdu2.redhat.com", image: "registry.redhat.io/rhel9/support-tools", command: "list tables")
  ⎿ {                                                                                                                                                    
      "data": "table ip filter\ntable ip mangle\ntable ip6 mangle\ntable ip nat\ntable ip6 nat\ntable ip6 filter\ntable ip raw\ntable ip6 raw\ntable inet
     ovn-kubernetes\n"
    }
