### PR TITLE
Add Default Timeouts for All Tool Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The server currently supports 2 transport modes: `stdio` and `http`.
 | `--pwru-image` | `docker.io/cilium/pwru:v1.0.10` | Container image for the **pwru** network tool (kernel packet tracing). |
 | `--tcpdump-image` | `nicolaka/netshoot:v0.15`       | Container image for the **tcpdump** network tool (packet capture). |
 | `--kernel-image` | `nicolaka/netshoot:v0.15`       | Container image for kernel tools (conntrack, ip, iptables, nft). |
+| `--tool-timeout` | `120`                           | Timeout in seconds for tool operations. Set to `0` to disable. |
 
 ### Live Cluster Mode
 

--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	kernelmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/mcp"
 	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/middleware"
 	mustgathermcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/must-gather/mcp"
 	nettoolsmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/network-tools/mcp"
 	ovnmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovn/mcp"
@@ -30,6 +32,7 @@ type MCPServerConfig struct {
 	TcpdumpImage string
 	Kernel       kernelmcp.Config
 	Kubernetes   kubernetesmcp.Config
+	ToolTimeout  time.Duration
 }
 
 // setupLiveCluster sets up the live cluster mode.
@@ -80,6 +83,11 @@ func main() {
 		&mcp.Implementation{Name: "ovn-kubernetes"},
 		&mcp.ServerOptions{HasTools: true},
 	)
+
+	// Apply timeout middleware to all tool calls if configured.
+	if serverCfg.ToolTimeout > 0 {
+		ovnkMcpServer.AddReceivingMiddleware(middleware.ToolTimeout(serverCfg.ToolTimeout))
+	}
 
 	// Setup the MCP server based on the mode.
 	switch serverCfg.Mode {
@@ -146,13 +154,31 @@ func main() {
 
 func parseFlags() *MCPServerConfig {
 	cfg := &MCPServerConfig{}
+	var timeoutSeconds int
+
 	flag.StringVar(&cfg.Mode, "mode", "live-cluster", "Mode of debugging: live-cluster or offline or dual")
 	flag.StringVar(&cfg.Transport, "transport", "stdio", "Transport to use: stdio or http")
 	flag.StringVar(&cfg.Port, "port", "8080", "Port to use")
 	flag.StringVar(&cfg.Kubernetes.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 	flag.StringVar(&cfg.PwruImage, "pwru-image", "docker.io/cilium/pwru:v1.0.10", "Container image for pwru operations")
+
 	flag.StringVar(&cfg.TcpdumpImage, "tcpdump-image", defaultNetshootImage, "Container image for tcpdump operations")
 	flag.StringVar(&cfg.Kernel.Image, "kernel-image", defaultNetshootImage, "Container image for kernel operations")
+	flag.IntVar(&timeoutSeconds, "tool-timeout", 120, "Timeout in seconds for tool operations (0 to disable)")
 	flag.Parse()
+
+	// Convert timeout to duration and apply limits
+	if timeoutSeconds < 0 {
+		timeoutSeconds = 120
+	}
+
+	cfg.ToolTimeout = time.Duration(timeoutSeconds) * time.Second
+
+	if cfg.ToolTimeout == 0 {
+		log.Println("Tool timeout enforcement disabled")
+	} else {
+		log.Printf("Tool timeout: %v", cfg.ToolTimeout)
+	}
+
 	return cfg
 }

--- a/pkg/kernel/mcp/conntrack.go
+++ b/pkg/kernel/mcp/conntrack.go
@@ -32,15 +32,13 @@ func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, 
 	var stdout string
 	if !conntrackCliAvailable {
 		stdout, err = s.getConntrackFromFile(ctx, req, in.Node)
-		if err != nil {
-			return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
-		}
 	} else {
 		stdout, err = s.getConntrackUsingCLI(ctx, req, in.Node, in.Command, in.FilterParameters)
-		if err != nil {
-			return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
-		}
 	}
+	if err != nil {
+		return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
+	}
+
 	stdout = limitOutputLines(stdout, in.MaxLines)
 	return nil, types.Result{Data: stdout}, nil
 }

--- a/pkg/kubernetes/client/resources.go
+++ b/pkg/kubernetes/client/resources.go
@@ -24,7 +24,7 @@ func (c *OVNKMCPServerClientSet) isNamespaced(group, version, kind string) (bool
 }
 
 // GetResource gets a resource by group, version, kind, name and namespace.
-func (c *OVNKMCPServerClientSet) GetResource(group, version, kind, resourceName, namespace string) (*unstructured.Unstructured, error) {
+func (c *OVNKMCPServerClientSet) GetResource(ctx context.Context, group, version, kind, resourceName, namespace string) (*unstructured.Unstructured, error) {
 	// If the namespace is not set, set it to the default namespace
 	// if the resource is namespaced.
 	if namespace == "" {
@@ -46,13 +46,13 @@ func (c *OVNKMCPServerClientSet) GetResource(group, version, kind, resourceName,
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST mapping for resource %s: %w", gvk.String(), err)
 	}
-	return c.getResource(restMapping.Resource, resourceName, namespace)
+	return c.getResource(ctx, restMapping.Resource, resourceName, namespace)
 }
 
 // getResource gets a resource by group, version, kind, name and namespace.
-func (c *OVNKMCPServerClientSet) getResource(gvr schema.GroupVersionResource, resourceName, namespace string) (*unstructured.Unstructured, error) {
+func (c *OVNKMCPServerClientSet) getResource(ctx context.Context, gvr schema.GroupVersionResource, resourceName, namespace string) (*unstructured.Unstructured, error) {
 	resource, err := c.dynamicClient.Resource(gvr).Namespace(namespace).
-		Get(context.Background(), resourceName, metav1.GetOptions{})
+		Get(ctx, resourceName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch resource %s with name %s and namespace %s: %w", gvr.String(), resourceName, namespace, err)
 	}
@@ -60,7 +60,7 @@ func (c *OVNKMCPServerClientSet) getResource(gvr schema.GroupVersionResource, re
 }
 
 // ListResources lists resources by group, version, kind and namespace.
-func (c *OVNKMCPServerClientSet) ListResources(group, version, kind, namespace, labelSelector string) (*unstructured.UnstructuredList, error) {
+func (c *OVNKMCPServerClientSet) ListResources(ctx context.Context, group, version, kind, namespace, labelSelector string) (*unstructured.UnstructuredList, error) {
 	gvk := schema.GroupVersionKind{
 		Group:   group,
 		Version: version,
@@ -70,12 +70,12 @@ func (c *OVNKMCPServerClientSet) ListResources(group, version, kind, namespace, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST mapping for resource %s: %w", gvk.String(), err)
 	}
-	return c.listResources(restMapping.Resource, namespace, labelSelector)
+	return c.listResources(ctx, restMapping.Resource, namespace, labelSelector)
 }
 
 // listResources lists resources by group, version, kind and namespace.
-func (c *OVNKMCPServerClientSet) listResources(gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error) {
-	resources, err := c.dynamicClient.Resource(gvr).Namespace(namespace).List(context.Background(), metav1.ListOptions{
+func (c *OVNKMCPServerClientSet) listResources(ctx context.Context, gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error) {
+	resources, err := c.dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {

--- a/pkg/kubernetes/client/resources_test.go
+++ b/pkg/kubernetes/client/resources_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -65,7 +66,7 @@ func TestGetResource(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeclient := NewFakeClient(test.object)
-			resource, err := fakeclient.GetResource(test.gvk.Group, test.gvk.Version, test.gvk.Kind, test.objectName, test.namespace)
+			resource, err := fakeclient.GetResource(context.Background(), test.gvk.Group, test.gvk.Version, test.gvk.Kind, test.objectName, test.namespace)
 			if (err != nil) != test.expectedErr {
 				t.Fatalf("Failed to get resource: %v", err)
 			}
@@ -366,7 +367,7 @@ func TestListResources(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeclient := NewFakeClient(test.objects...)
-			resources, err := fakeclient.ListResources(test.gvk.Group, test.gvk.Version, test.gvk.Kind, test.namespace, test.labelSelector)
+			resources, err := fakeclient.ListResources(context.Background(), test.gvk.Group, test.gvk.Version, test.gvk.Kind, test.namespace, test.labelSelector)
 			if (err != nil) != test.expectedErr {
 				t.Fatalf("Failed to list resources: %v", err)
 			}

--- a/pkg/kubernetes/mcp/resources.go
+++ b/pkg/kubernetes/mcp/resources.go
@@ -30,7 +30,7 @@ func (s *MCPServer) GetResource(ctx context.Context, req *mcp.CallToolRequest, i
 	}
 
 	// Get the resource by group, version, kind, name and namespace.
-	resource, err := s.clientSet.GetResource(in.Group, in.Version, in.Kind, in.Name, in.Namespace)
+	resource, err := s.clientSet.GetResource(ctx, in.Group, in.Version, in.Kind, in.Name, in.Namespace)
 	if err != nil {
 		return nil, types.GetResourceResult{}, err
 	}
@@ -82,7 +82,7 @@ func (s *MCPServer) ListResources(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	// List the resources by group, version, kind and namespace.
-	resources, err := s.clientSet.ListResources(in.Group, in.Version, in.Kind, in.Namespace, in.LabelSelector)
+	resources, err := s.clientSet.ListResources(ctx, in.Group, in.Version, in.Kind, in.Namespace, in.LabelSelector)
 	if err != nil {
 		return nil, types.ListResourcesResult{}, err
 	}

--- a/pkg/middleware/timeout.go
+++ b/pkg/middleware/timeout.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ToolTimeout returns an MCP receiving middleware that applies a context
+// timeout to every tools/call request. This ensures all tool operations
+// have a bounded execution time without requiring per-tool code.
+func ToolTimeout(timeout time.Duration) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if method != "tools/call" {
+				return next(ctx, method, req)
+			}
+
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			return next(ctx, method, req)
+		}
+	}
+}

--- a/pkg/middleware/timeout_test.go
+++ b/pkg/middleware/timeout_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestToolTimeout(t *testing.T) {
+	t.Run("applies deadline to tools/call", func(t *testing.T) {
+		timeout := 200 * time.Millisecond
+		m := ToolTimeout(timeout)
+
+		var capturedCtx context.Context
+		handler := m(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			capturedCtx = ctx
+			return nil, nil
+		})
+
+		_, _ = handler(context.Background(), "tools/call", nil)
+
+		deadline, ok := capturedCtx.Deadline()
+		if !ok {
+			t.Fatal("expected context to have a deadline for tools/call")
+		}
+		if time.Until(deadline) > timeout {
+			t.Fatalf("deadline too far in the future: %v", time.Until(deadline))
+		}
+	})
+
+	t.Run("no deadline for other methods", func(t *testing.T) {
+		m := ToolTimeout(200 * time.Millisecond)
+
+		var capturedCtx context.Context
+		handler := m(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			capturedCtx = ctx
+			return nil, nil
+		})
+
+		_, _ = handler(context.Background(), "initialize", nil)
+
+		if _, ok := capturedCtx.Deadline(); ok {
+			t.Fatal("expected no deadline for non-tools/call method")
+		}
+	})
+
+	t.Run("timeout fires when handler is slow", func(t *testing.T) {
+		m := ToolTimeout(10 * time.Millisecond)
+
+		handler := m(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			time.Sleep(50 * time.Millisecond)
+			return nil, ctx.Err()
+		})
+
+		_, err := handler(context.Background(), "tools/call", nil)
+		if err != context.DeadlineExceeded {
+			t.Fatalf("expected DeadlineExceeded, got: %v", err)
+		}
+	})
+
+	t.Run("no timeout when handler completes in time", func(t *testing.T) {
+		m := ToolTimeout(200 * time.Millisecond)
+
+		handler := m(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			time.Sleep(5 * time.Millisecond)
+			return nil, ctx.Err()
+		})
+
+		_, err := handler(context.Background(), "tools/call", nil)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
 - This commit is adding default timeout to all the tools involving fetching data from live k8s cluster
 - appropriate message is being shown, which is inturn forwarded to LLM
 - Default timeout is set to 60s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable tool execution timeout via --tool-timeout (seconds); when enabled, tool calls are time-limited and timed-out calls yield a standardized timeout error result.

* **Improvements**
  * Kubernetes resource Get/List now respect caller contexts for proper cancellation and deadlines.

* **Bug Fixes**
  * Simplified conntrack retrieval error handling to remove duplicated early returns.

* **Chores**
  * Minor formatting and newline cleanup.

* **Tests**
  * Added tests covering the tool-timeout middleware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->