### PR TITLE
Add jsonpath in the get and list tools of kubernetes and must-gather layers

### DIFF
--- a/pkg/kubernetes/mcp/mcp.go
+++ b/pkg/kubernetes/mcp/mcp.go
@@ -94,7 +94,7 @@ Parameters:
 - kind (required): Kind of the resource (e.g., "Pod", "Service", "Deployment", "ConfigMap")
 - name (required): Name of the resource to retrieve
 - namespace (optional): Namespace of the resource. If omitted, defaults to "default" for namespaced resources and empty for cluster-scoped resources
-- output_type (optional): Output format - 'yaml', 'json', or 'wide' (default: table format with name, namespace, age. wide will include labels and annotations)
+- output_type (optional): Output format - 'yaml', 'json', 'jsonpath', or 'wide' (default: table format with name, namespace, age. wide will include labels and annotations)
 
 Returns the resource definition in the requested format. Use this to inspect specific
 resource configurations, status, and metadata.
@@ -104,6 +104,7 @@ Examples:
 - Get a deployment as YAML: {"group": "apps", "version": "v1", "kind": "Deployment", "name": "my-deployment", "namespace": "default", "output_type": "yaml"}
 - Get a node (cluster-scoped): {"version": "v1", "kind": "Node", "name": "worker-0"}
 - Get a config map as JSON: {"version": "v1", "kind": "ConfigMap", "name": "my-config", "namespace": "kube-system", "output_type": "json"}
+- Get a pod name as JSONPath: {"version": "v1", "kind": "Pod", "name": "my-pod", "namespace": "default", "output_type": "jsonpath='{.metadata.name}'"}
 - Get detailed info: {"version": "v1", "kind": "Pod", "name": "my-pod", "namespace": "default", "output_type": "wide"}`,
 		}, s.GetResource)
 
@@ -121,7 +122,7 @@ Parameters:
 - kind (required): Kind of the resource (e.g., "Pod", "Service", "Deployment")
 - namespace (optional): Filter by namespace. If omitted, lists resources across all namespaces
 - label_selector (optional): Filter by label selector (e.g., "app=my-app", "component=network")
-- output_type (optional): Output format - 'yaml', 'json', or 'wide' (default: table format with name, namespace, age. wide will include labels and annotations)
+- output_type (optional): Output format - 'yaml', 'json', 'jsonpath', or 'wide' (default: table format with name, namespace, age. wide will include labels and annotations)
 
 Returns a list of matching resources. Use this to discover what resources exist in the
 cluster before retrieving specific ones with resource-get.
@@ -132,6 +133,7 @@ Examples:
 - List pods by label: {"version": "v1", "kind": "Pod", "namespace": "default", "label_selector": "app=my-app"}
 - List deployments as YAML: {"group": "apps", "version": "v1", "kind": "Deployment", "namespace": "default", "output_type": "yaml"}
 - List all nodes: {"version": "v1", "kind": "Node"}
-- List with detailed info: {"version": "v1", "kind": "Pod", "namespace": "kube-system", "output_type": "wide"}`,
+- List with detailed info: {"version": "v1", "kind": "Pod", "namespace": "kube-system", "output_type": "wide"}
+- List pod names as JSONPath: {"version": "v1", "kind": "Pod", "namespace": "default", "output_type": "jsonpath='{.items[*].metadata.name}'"}`,
 		}, s.ListResources)
 }

--- a/pkg/kubernetes/mcp/resources.go
+++ b/pkg/kubernetes/mcp/resources.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
@@ -20,6 +21,9 @@ func (s *MCPServer) GetResource(ctx context.Context, req *mcp.CallToolRequest, i
 	}
 	if in.Name == "" {
 		err = errors.Join(err, errors.New("name is required"))
+	}
+	if errOutputParams := in.OutputParams.ValidateOutputParams(); errOutputParams != nil {
+		err = errors.Join(err, errOutputParams)
 	}
 	if err != nil {
 		return nil, types.GetResourceResult{}, err
@@ -45,8 +49,16 @@ func (s *MCPServer) GetResource(ctx context.Context, req *mcp.CallToolRequest, i
 			return nil, types.GetResourceResult{}, err
 		}
 	default:
-		// If the output type is not JSON or YAML, get the resource data.
-		resourceData.GetResourceData(resource, in.OutputType == types.WideOutputType)
+		// If the output type is jsonpath, get the jsonpath data from the resource.
+		if jsonPathTemplate, found := strings.CutPrefix(string(in.OutputType), string(types.JSONPathOutputType)+"="); found {
+			err = resourceData.ToJSONPath(jsonPathTemplate, resource.UnstructuredContent())
+			if err != nil {
+				return nil, types.GetResourceResult{}, err
+			}
+		} else {
+			// If the output type is not json, yaml or jsonpath, get the resource data.
+			resourceData.GetResourceData(resource, in.OutputType == types.WideOutputType)
+		}
 	}
 
 	return nil, types.GetResourceResult{Resource: resourceData}, nil
@@ -61,6 +73,9 @@ func (s *MCPServer) ListResources(ctx context.Context, req *mcp.CallToolRequest,
 	}
 	if in.Kind == "" {
 		err = errors.Join(err, errors.New("kind is required"))
+	}
+	if errOutputParams := in.OutputParams.ValidateOutputParams(); errOutputParams != nil {
+		err = errors.Join(err, errOutputParams)
 	}
 	if err != nil {
 		return nil, types.ListResourcesResult{}, err
@@ -78,26 +93,36 @@ func (s *MCPServer) ListResources(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	resourcesData := make([]types.Resource, 0)
-	// Loop through the resources and get the resource data.
-	for _, resource := range resources.Items {
+	// If the output type is jsonpath, get the jsonpath data from the resources.
+	if jsonPathTemplate, found := strings.CutPrefix(string(in.OutputType), string(types.JSONPathOutputType)+"="); found {
 		resourceData := types.Resource{}
-		// Get the formatted data from the resource.
-		switch in.OutputType {
-		case types.JSONOutputType:
-			err = resourceData.ToJSON(&resource)
-			if err != nil {
-				return nil, types.ListResourcesResult{}, err
-			}
-		case types.YAMLOutputType:
-			err = resourceData.ToYAML(&resource)
-			if err != nil {
-				return nil, types.ListResourcesResult{}, err
-			}
-		default:
-			// If the output type is not JSON or YAML, get the resource data.
-			resourceData.GetResourceData(&resource, in.OutputType == types.WideOutputType)
+		err = resourceData.ToJSONPath(jsonPathTemplate, resources.UnstructuredContent())
+		if err != nil {
+			return nil, types.ListResourcesResult{}, err
 		}
 		resourcesData = append(resourcesData, resourceData)
+	} else {
+		// Loop through the resources and get the resource data.
+		for _, resource := range resources.Items {
+			resourceData := types.Resource{}
+			// Get the formatted data from the resource.
+			switch in.OutputType {
+			case types.JSONOutputType:
+				err = resourceData.ToJSON(&resource)
+				if err != nil {
+					return nil, types.ListResourcesResult{}, err
+				}
+			case types.YAMLOutputType:
+				err = resourceData.ToYAML(&resource)
+				if err != nil {
+					return nil, types.ListResourcesResult{}, err
+				}
+			default:
+				// If the output type is not json, yaml or jsonpath, get the resource data.
+				resourceData.GetResourceData(&resource, in.OutputType == types.WideOutputType)
+			}
+			resourcesData = append(resourcesData, resourceData)
+		}
 	}
 
 	return nil, types.ListResourcesResult{Resources: resourcesData}, nil

--- a/pkg/kubernetes/types/common.go
+++ b/pkg/kubernetes/types/common.go
@@ -1,10 +1,14 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/jsonpath"
 	yaml "sigs.k8s.io/yaml"
 )
 
@@ -20,6 +24,21 @@ func (j *FormattedOutput) ToJSON(data any) error {
 		return err
 	}
 	j.Data = string(jsonData)
+	return nil
+}
+
+// ToJSONPath gets the JSONPath data from a resource.
+func (j *FormattedOutput) ToJSONPath(template string, data map[string]any) error {
+	jp := jsonpath.New("jsonpath")
+	if err := jp.Parse(template); err != nil {
+		return err
+	}
+	dataBuffer := bytes.NewBuffer(nil)
+	err := jp.Execute(dataBuffer, data)
+	if err != nil {
+		return fmt.Errorf("failed to execute jsonpath template %s, error: %w", template, err)
+	}
+	j.Data = dataBuffer.String()
 	return nil
 }
 
@@ -78,17 +97,41 @@ type GroupVersionKind struct {
 type OutputType string
 
 const (
-	// YAMLOutputType is the output type for YAML data.
+	// YAMLOutputType is the output type for yaml data.
 	YAMLOutputType OutputType = "yaml"
-	// JSONOutputType is the output type for JSON data.
+	// JSONOutputType is the output type for json data.
 	JSONOutputType OutputType = "json"
+	// JSONPathOutputType is the output type for jsonpath data.
+	JSONPathOutputType OutputType = "jsonpath"
 	// WideOutputType is the output type for detailed data.
 	WideOutputType OutputType = "wide"
 )
 
+// OutputParams is a type that contains the output type and JSONPathTemplate of a resource.
+type OutputParams struct {
+	// OutputType is the output type of the resource. If set, it can be yaml, json, jsonpath or wide.
+	// For jsonpath, the template should be provided as part of the output type.
+	// For example, output_type="jsonpath='{.metadata.name}'".
+	OutputType OutputType `json:"output_type,omitempty"`
+}
+
+// ValidateOutputParams validates the output parameters.
+func (o *OutputParams) ValidateOutputParams() error {
+	if o.OutputType != "" && o.OutputType != YAMLOutputType && o.OutputType != JSONOutputType &&
+		o.OutputType != WideOutputType && !strings.HasPrefix(string(o.OutputType), string(JSONPathOutputType)+"=") {
+		return fmt.Errorf("invalid output_type: %s", o.OutputType)
+	}
+	if jsonPathTemplate, found := strings.CutPrefix(string(o.OutputType), string(JSONPathOutputType)+"="); found {
+		err := jsonpath.NewParser("validate").Parse(jsonPathTemplate)
+		if err != nil {
+			return fmt.Errorf("invalid json_path_template: %s, error: %w", jsonPathTemplate, err)
+		}
+	}
+	return nil
+}
+
 // GetParams is a type that contains the name, namespace and output type of a resource.
 type GetParams struct {
 	NamespacedNameParams
-	// OutputType is the output type of the resource. If set, it can be YAML, JSON or wide.
-	OutputType OutputType `json:"output_type,omitempty"`
+	OutputParams
 }

--- a/pkg/kubernetes/types/resources.go
+++ b/pkg/kubernetes/types/resources.go
@@ -15,8 +15,7 @@ type GetResourceResult struct {
 type ListParams struct {
 	Namespace     string `json:"namespace,omitempty"`
 	LabelSelector string `json:"label_selector,omitempty"`
-	// OutputType is the output type of the resource. If set, it can be YAML, JSON or wide.
-	OutputType OutputType `json:"output_type,omitempty"`
+	OutputParams
 }
 
 // ListResourcesParams is a type that contains the group, version, kind, namespace and output type of a resource.

--- a/pkg/must-gather/mcp/mcp.go
+++ b/pkg/must-gather/mcp/mcp.go
@@ -43,7 +43,7 @@ Parameters:
 - kind (required): Kubernetes resource kind (e.g., Pod, Service, Node, Deployment, ConfigMap)
 - name (required): Name of the resource to retrieve
 - namespace (optional): Namespace of the resource (defaults to "default" for namespaced resources)
-- output_type (optional): Output format - 'yaml', 'json', or 'wide' (default: table format)
+- output_type (optional): Output format - 'yaml', 'json', 'wide', or 'jsonpath' (default: table format)
 
 Returns the resource definition in the requested format. Use this to inspect specific
 resource configurations, status, and metadata from the must-gather snapshot.
@@ -51,7 +51,8 @@ resource configurations, status, and metadata from the must-gather snapshot.
 Examples:
 - Get a pod: {"must_gather_path": "/path/to/must-gather", "kind": "Pod", "namespace": "default", "name": "my-pod"}
 - Get a node as YAML: {"must_gather_path": "/path/to/must-gather", "kind": "Node", "name": "worker-0", "output_type": "yaml"}
-- Get a config map: {"must_gather_path": "/path/to/must-gather", "kind": "ConfigMap", "namespace": "kube-system", "name": "my-config"}`,
+- Get a config map: {"must_gather_path": "/path/to/must-gather", "kind": "ConfigMap", "namespace": "kube-system", "name": "my-config"}
+- Get a pod name as JSONPath: {"must_gather_path": "/path/to/must-gather", "kind": "Pod", "namespace": "default", "name": "my-pod", "output_type": "jsonpath='{.metadata.name}'"}`,
 	}, s.GetResource)
 
 	mcp.AddTool(server, &mcp.Tool{
@@ -63,7 +64,7 @@ Parameters:
 - kind (required): Kubernetes resource kind (e.g., Pod, Service, Node, Deployment)
 - namespace (optional): Filter by namespace. If omitted, lists resources across all namespaces
 - label_selector (optional): Filter by label selector (e.g., 'app=ovnkube-node', 'component=network')
-- output_type (optional): Output format - 'yaml', 'json', or 'wide' (default: table format)
+- output_type (optional): Output format - 'yaml', 'json', 'wide', or 'jsonpath' (default: table format)
 
 Returns a list of matching resources. Use this to discover what resources exist in the
 must-gather snapshot before retrieving specific ones with must-gather-get-resource.
@@ -72,7 +73,8 @@ Examples:
 - List all pods in a namespace: {"must_gather_path": "/path/to/must-gather", "kind": "Pod", "namespace": "default"}
 - List all nodes: {"must_gather_path": "/path/to/must-gather", "kind": "Node"}
 - List pods by label: {"must_gather_path": "/path/to/must-gather", "kind": "Pod", "label_selector": "app=my-app"}
-- List services as JSON: {"must_gather_path": "/path/to/must-gather", "kind": "Service", "namespace": "kube-system", "output_type": "json"}`,
+- List services as JSON: {"must_gather_path": "/path/to/must-gather", "kind": "Service", "namespace": "kube-system", "output_type": "json"}
+- List pod names as JSONPath: {"must_gather_path": "/path/to/must-gather", "kind": "Pod", "namespace": "default", "output_type": "jsonpath='{.items[*].metadata.name}'"}`,
 	}, s.ListResources)
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/pkg/must-gather/mcp/resources.go
+++ b/pkg/must-gather/mcp/resources.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/must-gather/types"
@@ -20,11 +19,14 @@ func (s *MustGatherMCPServer) GetResource(ctx context.Context, req *mcp.CallTool
 	if in.Name == "" {
 		err = errors.Join(err, errors.New("name is required"))
 	}
+	if errOutputParams := in.OutputParams.ValidateOutputParams(); errOutputParams != nil {
+		err = errors.Join(err, errOutputParams)
+	}
 	if err != nil {
 		return nil, types.ResourceResult{}, err
 	}
 
-	output, err := s.omcClient.GetResource(ctx, in.MustGatherPath, in.Kind, in.Namespace, in.Name, in.OutputType)
+	output, err := s.omcClient.GetResource(ctx, in.MustGatherPath, in.Kind, in.Namespace, in.Name, in.OutputParams)
 	if err != nil {
 		return nil, types.ResourceResult{}, err
 	}
@@ -35,11 +37,18 @@ func (s *MustGatherMCPServer) GetResource(ctx context.Context, req *mcp.CallTool
 // must gather path is not valid.
 func (s *MustGatherMCPServer) ListResources(ctx context.Context, req *mcp.CallToolRequest, in types.ListResourcesParams) (*mcp.CallToolResult, types.ResourceResult, error) {
 	// If the kind is not set, return an error.
+	var err error
 	if in.Kind == "" {
-		return nil, types.ResourceResult{}, fmt.Errorf("kind is required")
+		err = errors.New("kind is required")
+	}
+	if errOutputParams := in.OutputParams.ValidateOutputParams(); errOutputParams != nil {
+		err = errors.Join(err, errOutputParams)
+	}
+	if err != nil {
+		return nil, types.ResourceResult{}, err
 	}
 
-	output, err := s.omcClient.ListResources(ctx, in.MustGatherPath, in.Kind, in.Namespace, in.LabelSelector, in.OutputType)
+	output, err := s.omcClient.ListResources(ctx, in.MustGatherPath, in.Kind, in.Namespace, in.LabelSelector, in.OutputParams)
 	if err != nil {
 		return nil, types.ResourceResult{}, err
 	}

--- a/pkg/must-gather/omc-client/resources.go
+++ b/pkg/must-gather/omc-client/resources.go
@@ -12,7 +12,7 @@ import (
 
 // GetResource uses the omc command to get a resource. It will return an error if the
 // must gather path is not valid or the resource is not found.
-func (c *OmcClient) GetResource(ctx context.Context, mustGatherPath string, kind string, namespace, name string, outputType k8sTypes.OutputType) (string, error) {
+func (c *OmcClient) GetResource(ctx context.Context, mustGatherPath string, kind string, namespace, name string, outputParams k8sTypes.OutputParams) (string, error) {
 	// Validate the kind
 	if err := validateKubernetesName(kind, false); err != nil {
 		return "", fmt.Errorf("failed to validate kind: %w", err)
@@ -46,7 +46,7 @@ func (c *OmcClient) GetResource(ctx context.Context, mustGatherPath string, kind
 	}
 	args = append(args, "-n", namespace)
 	// Append the output type arguments
-	args = appendOutputTypeArgs(args, outputType)
+	args = appendOutputTypeArgs(args, outputParams)
 
 	// Get the resource from the omc command
 	output, err := exec.CommandContext(ctx, c.commandPath, args...).CombinedOutput()
@@ -63,7 +63,7 @@ func (c *OmcClient) GetResource(ctx context.Context, mustGatherPath string, kind
 
 // ListResources uses the omc command to list resources. It will return an error if the
 // must gather path is not valid.
-func (c *OmcClient) ListResources(ctx context.Context, mustGatherPath string, kind string, namespace string, labelSelector string, outputType k8sTypes.OutputType) (string, error) {
+func (c *OmcClient) ListResources(ctx context.Context, mustGatherPath string, kind string, namespace string, labelSelector string, outputParams k8sTypes.OutputParams) (string, error) {
 	// Validate the kind
 	if err := validateKubernetesName(kind, false); err != nil {
 		return "", fmt.Errorf("failed to validate kind: %w", err)
@@ -96,7 +96,7 @@ func (c *OmcClient) ListResources(ctx context.Context, mustGatherPath string, ki
 		args = append(args, "-l", labelSelector)
 	}
 	// Append the output type arguments
-	args = appendOutputTypeArgs(args, outputType)
+	args = appendOutputTypeArgs(args, outputParams)
 	// Append the namespace argument
 	if namespace != "" {
 		args = append(args, "-n", namespace)
@@ -113,7 +113,7 @@ func (c *OmcClient) ListResources(ctx context.Context, mustGatherPath string, ki
 	// If the output contains "No resources", return an empty string.
 	if strings.Contains(strings.ToLower(string(output)), "no resources") {
 		// Format the output based on the output type.
-		switch outputType {
+		switch outputParams.OutputType {
 		case k8sTypes.JSONOutputType:
 			return `{
   "apiVersion": "v1",
@@ -133,14 +133,17 @@ items: []`, nil
 }
 
 // appendOutputTypeArgs appends the output type arguments to the arguments.
-func appendOutputTypeArgs(args []string, outputType k8sTypes.OutputType) []string {
-	switch outputType {
+func appendOutputTypeArgs(args []string, outputParams k8sTypes.OutputParams) []string {
+	switch outputParams.OutputType {
 	case k8sTypes.JSONOutputType:
 		return append(args, "-o", "json")
 	case k8sTypes.YAMLOutputType:
 		return append(args, "-o", "yaml")
 	case k8sTypes.WideOutputType:
 		return append(args, "-o", "wide")
+	}
+	if strings.HasPrefix(string(outputParams.OutputType), string(k8sTypes.JSONPathOutputType)+"=") {
+		return append(args, "-o", string(outputParams.OutputType))
 	}
 	return args
 }

--- a/pkg/must-gather/ovsdb-tool/list-dbs.go
+++ b/pkg/must-gather/ovsdb-tool/list-dbs.go
@@ -57,7 +57,7 @@ func (s *OvsdbTool) getDatabaseToNodeMapping(ctx context.Context, mustGatherPath
 	}
 
 	// Get the list of all the pods
-	data, err := s.omcClient.ListResources(ctx, mustGatherPath, "pod", "", ovnkubeNodeLabelSelector, k8sTypes.JSONOutputType)
+	data, err := s.omcClient.ListResources(ctx, mustGatherPath, "pod", "", ovnkubeNodeLabelSelector, k8sTypes.OutputParams{OutputType: k8sTypes.JSONOutputType})
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods: %w", err)
 	}


### PR DESCRIPTION
Fixes #41

To get the values of different fields, only json and yaml are the current options in the get and list tools of kubernetes and must-gather layers. This can easily cause the context limit of LLM models to be breached.

This PR adds the support for jsonpath. This will enable fetching the same information without receiving the full json/yaml data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSONPath as a supported output format for resource get/list operations (use output_type="jsonpath='<template>'" to extract fields).

* **Bug Fixes**
  * Improved validation and consolidated error reporting for output parameters; invalid or missing JSONPath templates are caught earlier.

* **Documentation**
  * Updated help text and examples to demonstrate jsonpath usage and corrected example formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->