### PR TITLE
Deploy MCP server in a cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# IDE
+.cursor
+.cursorignore
+
+# Build output and local artifacts
+_output
+
+# Docs and project files (not needed for build)
+*.md
+MAINTAINERS
+LICENSE
+
+# Test and hack (not needed in image)
+test
+hack
+
+# Kubernetes config (not needed in image)
+config
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Vendor is re-fetched via go mod download in the image
+vendor
+
+# Misc
+*.tmp
+*.log
+*.swp
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Build stage – use Go image to match go.mod (set via build-arg from Makefile)
+ARG GOLANG_IMAGE=quay.io/projectquay/golang
+ARG GOLANG_VERSION=1.24
+FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS builder
+WORKDIR /build
+
+ENV CGO_ENABLED=0
+ENV GOPATH=/go
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN make build
+
+# Runtime stage – minimal image
+FROM alpine:3.23
+RUN apk add --no-cache ca-certificates
+RUN adduser -D -u 1000 -g root mcp
+USER 1000:0
+
+COPY --from=builder /build/_output/ovnk-mcp-server /usr/local/bin/ovnk-mcp-server
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/ovnk-mcp-server"]
+CMD ["--transport=http", "--host=0.0.0.0", "--port=8080", "--mode=live-cluster"]

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,109 @@ GOPATH ?= $(shell go env GOPATH)
 build:
 	go build -o $(MCP_SERVER_PATH) cmd/ovnk-mcp-server/main.go
 
+# Container image build targets (use IMAGE to override tag, e.g. make build-image IMAGE=quay.io/myorg/ovnk-mcp-server:v1.0)
+IMAGE ?= localhost/ovnk-mcp-server:dev
+export IMAGE
+GOLANG_IMAGE ?= quay.io/projectquay/golang
+GOLANG_VERSION ?= 1.24
+KUSTOMIZE_VERSION ?= v5.8.1
+K8S_VERSION ?= v1.34.1
+
+.PHONY: build-image
+build-image:
+	$(CONTAINER_RUNTIME) build -f Dockerfile \
+		--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		-t $(IMAGE) .
+
+LOCALBIN ?= $(GIT_ROOT)/_output/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary (ideally with version)
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(LOCALBIN) go install -mod=mod $${package} ;\
+mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+}
+endef
+
+# Prefer kustomize on PATH; install a pinned binary under LOCALBIN only when none is found.
+KUSTOMIZE_PATH := $(shell command -v kustomize 2>/dev/null)
+ifeq ($(strip $(KUSTOMIZE_PATH)),)
+KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
+else
+KUSTOMIZE ?= $(KUSTOMIZE_PATH)
+endif
+export KUSTOMIZE
+
+.PHONY: kustomize
+ifeq ($(strip $(KUSTOMIZE_PATH)),)
+kustomize: $(KUSTOMIZE) ## Download kustomize to LOCALBIN when not on PATH.
+$(KUSTOMIZE): $(LOCALBIN)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
+else
+kustomize: ## Using kustomize from PATH ($(KUSTOMIZE)); skip LOCALBIN install.
+	@true
+endif
+
+# Prefer kubectl on PATH; otherwise download the release binary to LOCALBIN (dl.k8s.io).
+KUBECTL_PATH := $(shell command -v kubectl 2>/dev/null)
+ifeq ($(strip $(KUBECTL_PATH)),)
+KUBECTL ?= $(LOCALBIN)/kubectl-$(K8S_VERSION)
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+else
+KUBECTL ?= $(KUBECTL_PATH)
+endif
+export KUBECTL
+
+.PHONY: kubectl
+ifeq ($(strip $(KUBECTL_PATH)),)
+kubectl: $(KUBECTL) ## Download kubectl to LOCALBIN when not on PATH.
+$(KUBECTL): $(LOCALBIN)
+	@test -s $(KUBECTL) || { \
+	set -e; \
+	url="https://dl.k8s.io/$(K8S_VERSION)/bin/$(OS)/$(ARCH)/kubectl"; \
+	echo "Downloading kubectl $(K8S_VERSION) ($${url}) ..."; \
+	curl -fsSL "$${url}" -o "$(KUBECTL).tmp"; \
+	curl -fsSL "$${url}.sha256" -o "$(KUBECTL).sha256.tmp"; \
+	if command -v sha256sum >/dev/null 2>&1; then \
+		echo "$$(cat "$(KUBECTL).sha256.tmp")  $(KUBECTL).tmp" | sha256sum --check -; \
+	else \
+		echo "$$(cat "$(KUBECTL).sha256.tmp")  $(KUBECTL).tmp" | shasum -a 256 -c -; \
+	fi; \
+	chmod +x "$(KUBECTL).tmp" && mv -f "$(KUBECTL).tmp" "$(KUBECTL)"; \
+	rm -f "$(KUBECTL).sha256.tmp"; \
+	}
+else
+kubectl: ## Using kubectl from PATH ($(KUBECTL)); skip LOCALBIN install.
+	@true
+endif
+
+# Ephemeral copy of config/ for deploy-ovnk-mcp-k8s so kustomize edit does not modify tracked files.
+DEPLOY_OVNK_MCP_K8S_CONFIG := $(GIT_ROOT)/_output/deploy-ovnk-mcp-k8s-config
+
+.PHONY: deploy-ovnk-mcp-k8s
+deploy-ovnk-mcp-k8s: kustomize kubectl
+	rm -rf $(DEPLOY_OVNK_MCP_K8S_CONFIG)
+	mkdir -p $(DEPLOY_OVNK_MCP_K8S_CONFIG)
+	cp -a $(GIT_ROOT)/config/. $(DEPLOY_OVNK_MCP_K8S_CONFIG)/
+	cd $(DEPLOY_OVNK_MCP_K8S_CONFIG) && $(KUSTOMIZE) edit set image localhost/ovnk-mcp-server=$(IMAGE)
+	$(KUSTOMIZE) build $(DEPLOY_OVNK_MCP_K8S_CONFIG) | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build $(DEPLOY_OVNK_MCP_K8S_CONFIG)/debug-pod-rbac | $(KUBECTL) apply -f -
+
+.PHONY: undeploy-ovnk-mcp-k8s
+undeploy-ovnk-mcp-k8s: kustomize kubectl
+	$(KUSTOMIZE) build $(GIT_ROOT)/config | $(KUBECTL) delete --ignore-not-found=true -f -
+	$(KUSTOMIZE) build $(GIT_ROOT)/config/debug-pod-rbac | $(KUBECTL) delete --ignore-not-found=true -f -
+
 .PHONY: clean
 clean:
 	rm -Rf _output/
@@ -33,11 +136,11 @@ test:
 
 .PHONY: deploy-kind-ovnk
 deploy-kind-ovnk:
-	./hack/deploy-kind-ovnk.sh
+	@$(GIT_ROOT)/hack/deploy-kind-ovnk.sh
 
 .PHONY: undeploy-kind-ovnk
 undeploy-kind-ovnk:
-	./hack/undeploy-kind-ovnk.sh
+	@$(GIT_ROOT)/hack/undeploy-kind-ovnk.sh
 
 NVM_VERSION := 0.40.3
 NODE_VERSION := 22.20.0
@@ -47,7 +150,7 @@ MCP_MODE ?= live-cluster
 
 .PHONY: run-e2e
 run-e2e:
-	./hack/run-e2e.sh $(NVM_VERSION) $(NODE_VERSION) $(NPM_VERSION) $(GINKGO_VERSION) "$(MCP_MODE)" "$(FOCUS)"
+	@$(GIT_ROOT)/hack/run-e2e.sh $(NVM_VERSION) $(NODE_VERSION) $(NPM_VERSION) $(GINKGO_VERSION) "$(MCP_MODE)" "$(FOCUS)"
 
 .PHONY: test-e2e
 test-e2e: build
@@ -59,19 +162,19 @@ test-e2e: build
 .PHONY: lint
 lint:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	@GOPATH=${GOPATH} ./hack/lint.sh $(CONTAINER_RUNTIME) || { echo "lint failed! Try running 'make lint-fix'"; exit 1; }
+	@GOPATH=${GOPATH} $(GIT_ROOT)/hack/lint.sh $(CONTAINER_RUNTIME) || { echo "lint failed! Try running 'make lint-fix'"; exit 1; }
 else
 	echo "linter can only be run within a container since it needs a specific golangci-lint version"; exit 1
 endif
 
 .PHONY: update-readme-tools
 update-readme-tools:
-	go run ./hack/gen-readme-tools.go
+	go run $(GIT_ROOT)/hack/gen-readme-tools.go
 
 .PHONY: lint-fix
 lint-fix:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	@GOPATH=${GOPATH} ./hack/lint.sh ${CONTAINER_RUNTIME} fix || { echo "ERROR: lint fix failed! There is a bug that changes file ownership to root \
+	@GOPATH=${GOPATH} $(GIT_ROOT)/hack/lint.sh ${CONTAINER_RUNTIME} fix || { echo "ERROR: lint fix failed! There is a bug that changes file ownership to root \
 	when this happens. To fix it, simply run 'chown -R <user>:<group> *' from the repo root."; exit 1; }
 else
 	echo "linter can only be run within a container since it needs a specific golangci-lint version"; exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Get the Git repository root directory
-GIT_ROOT := $(shell git rev-parse --show-toplevel)
+export GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
 export MCP_SERVER_PATH := $(GIT_ROOT)/_output/ovnk-mcp-server
-export KUBECONFIG := $(HOME)/ovn.conf
+KUBECONFIG ?= $(HOME)/ovn.conf
+export KUBECONFIG
 
 # CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
 # podman/docker is installed on the system.
@@ -13,6 +14,8 @@ else
 CONTAINER_RUNTIME?=docker
 endif
 CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
+
+export CONTAINER_RUNTIME
 
 GOPATH ?= $(shell go env GOPATH)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Repo hosting the Model Context Protocol Server for troubleshooting OVN-Kubernete
   - [Offline Mode](#offline-mode)
   - [Dual Mode](#dual-mode)
   - [Local development](#local-development)
+  - [Kubernetes deployment](#kubernetes-deployment)
 - [Tools available in MCP Server](#tools-available-in-mcp-server)
   - [Live Cluster Mode](#live-cluster-mode-1)
   - [Offline Mode](#offline-mode-1)
@@ -39,8 +40,9 @@ The server currently supports 2 transport modes: `stdio` and `http`.
 |--------|---------------------------------|-------------|
 | `--mode` | `live-cluster`                  | Server mode: `live-cluster`, `offline`, or `dual`. |
 | `--transport` | `stdio`                         | Transport: `stdio` or `http`. |
+| `--host` | `localhost`                     | Address the HTTP server binds to (`http` only). Use `0.0.0.0` in a container so clients can reach the listener. |
 | `--port` | `8080`                          | Port for HTTP transport. |
-| `--kubeconfig` | (none)                          | Path to kubeconfig file. Required for `live-cluster` and `dual`. |
+| `--kubeconfig` | (none)                          | Path to kubeconfig file. Omit when using in-cluster **ServiceAccount** credentials (for example the pod deployment); otherwise set for `live-cluster` and `dual`. |
 | `--pwru-image` | `docker.io/cilium/pwru:v1.0.10` | Container image for the **pwru** network tool (kernel packet tracing). |
 | `--tcpdump-image` | `nicolaka/netshoot:v0.15`       | Container image for the **tcpdump** network tool (packet capture). |
 | `--kernel-image` | `nicolaka/netshoot:v0.15`       | Container image for kernel tools (conntrack, ip, iptables, nft). |
@@ -177,6 +179,74 @@ When developing or building locally, run `make build` and use the binary path as
 ```
 
 For `offline` mode, omit the `--kubeconfig` argument in dual examples above.
+
+### Kubernetes deployment
+
+The manifests under [`config/`](config/) run the server **in the cluster** as HTTP ([`config/deployment.yaml`](config/deployment.yaml)): `--transport=http`, `--host=0.0.0.0`, `--port=8080`, and `--mode=live-cluster`. There is **no** `--kubeconfig` argument in that deployment; the pod uses its **ServiceAccount** credentials to connect to the Kubernetes API server.
+
+Apply the manifests with:
+
+```shell
+make deploy-ovnk-mcp-k8s IMAGE=<your-registry>/ovnk-mcp-server:<tag>
+```
+
+`IMAGE` is optional if the image already matches what the manifests expect. Remove the stack with `make undeploy-ovnk-mcp-k8s`.
+
+**Service:** a `ClusterIP` Service `ovnk-mcp-server` in namespace `ovn-kubernetes-mcp` exposes port **8080** to the pod ([`config/service.yaml`](config/service.yaml)).
+
+**NetworkPolicy:** [`config/networkpolicy.yaml`](config/networkpolicy.yaml) selects the MCP server pod and sets **`ingress: []`**, which denies **all** ingress to that pod from the cluster network. So other workloads cannot reach the MCP HTTP endpoint through the Service, and there is no in-manifest Ingress or LoadBalancer for public access.
+
+**Connecting an LLM client (Cursor, Claude, and so on) from your machine:** the usual pattern is to use **`kubectl port-forward`** from a kube context that can access the cluster. That forwards a local port to the Service without relying on in-cluster ingress to the pod (the forward is set up by the kubelet). In one terminal:
+
+```shell
+kubectl port-forward -n ovn-kubernetes-mcp svc/ovnk-mcp-server 8080:8080
+```
+
+Then configure the host’s MCP client for **streamable HTTP** against the forwarded port (same shape as [HTTP live-cluster](#live-cluster-mode) above):
+
+```json
+{
+  "mcpServers": {
+    "ovn-kubernetes": {
+      "url": "http://127.0.0.1:8080"
+    }
+  }
+}
+```
+
+Keep the port-forward process running while you use the tools. The server URL is the **base** of the HTTP transport; clients that implement [MCP Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) negotiate on top of that.
+
+**Security note:** the shipped manifests do not add TLS or application-level auth on the MCP HTTP listener. Treat network access as sensitive: use port-forward or private networking, and rely on Kubernetes RBAC (who may port-forward or change `NetworkPolicy`) to limit who can reach the server.
+
+**Allowing only a trusted in-cluster pod:** leave [`config/networkpolicy.yaml`](config/networkpolicy.yaml) in place. For a pod that is allowed to talk to the MCP server (for example a single well-known automation or gateway workload), add a **second** `NetworkPolicy` in namespace `ovn-kubernetes-mcp`. Policies that select the same pod are [additive](https://kubernetes.io/docs/concepts/services-networking/network-policies/): allowed ingress is the **union** of every matching policy’s `ingress` rules, so the deny-all policy keeps every other source blocked while your new policy explicitly permits the trusted peer on port **8080** only.
+
+1. Give the trusted client pod a **narrow, unique** label (example below uses `app.kubernetes.io/name: ovnk-mcp-trusted-client`).
+2. Apply a policy that uses the **same** `podSelector` as the shipped policy (MCP server labels: `app.kubernetes.io/name: ovn-kubernetes-mcp` and `app.kubernetes.io/component: mcp-server`) and an `ingress` rule whose `from` matches only that client, with `ports` limited to `8080` / `TCP`.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ovnk-mcp-server-allow-trusted-client
+  namespace: ovn-kubernetes-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ovn-kubernetes-mcp
+      app.kubernetes.io/component: mcp-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ovnk-mcp-trusted-client
+      ports:
+        - port: 8080
+          protocol: TCP
+```
+
+From that client pod, call the Service at `http://ovnk-mcp-server.ovn-kubernetes-mcp.svc:8080` (or the fully qualified `*.svc.cluster.local` name). If the client runs in **another** namespace, use a `from` entry with both `namespaceSelector` and `podSelector` as described under [Targeting multiple namespaces by label](https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-multiple-namespaces-by-label). Prefer explicit labels over wide selectors, and keep trusting this path only for workloads you control—there is still no MCP-level authentication on the wire.
 
 ---
 

--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -27,6 +27,7 @@ const defaultNetshootImage = "nicolaka/netshoot:v0.15"
 type MCPServerConfig struct {
 	Mode         string
 	Transport    string
+	Host         string
 	Port         string
 	PwruImage    string
 	TcpdumpImage string
@@ -139,10 +140,13 @@ func main() {
 		handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 			return ovnkMcpServer
 		}, nil)
-		log.Printf("Listening on localhost:%s", serverCfg.Port)
+		addr := net.JoinHostPort(serverCfg.Host, serverCfg.Port)
+		log.Printf("Listening on %s", addr)
 		server = &http.Server{
-			Addr:    fmt.Sprintf("localhost:%s", serverCfg.Port),
-			Handler: handler,
+			Addr:              addr,
+			Handler:           handler,
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       60 * time.Second,
 		}
 		if err := server.ListenAndServe(); err != nil {
 			log.Printf("HTTP server failed: %v", err)
@@ -158,6 +162,7 @@ func parseFlags() *MCPServerConfig {
 
 	flag.StringVar(&cfg.Mode, "mode", "live-cluster", "Mode of debugging: live-cluster or offline or dual")
 	flag.StringVar(&cfg.Transport, "transport", "stdio", "Transport to use: stdio or http")
+	flag.StringVar(&cfg.Host, "host", "localhost", "Host to bind to (use 0.0.0.0 for container/cluster)")
 	flag.StringVar(&cfg.Port, "port", "8080", "Port to use")
 	flag.StringVar(&cfg.Kubernetes.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 	flag.StringVar(&cfg.PwruImage, "pwru-image", "docker.io/cilium/pwru:v1.0.10", "Container image for pwru operations")

--- a/config/debug-pod-rbac/kustomization.yaml
+++ b/config/debug-pod-rbac/kustomization.yaml
@@ -1,0 +1,11 @@
+# Separate kustomization so Role/RoleBinding stay in namespace "default".
+# The parent config/kustomization.yaml sets namespace: ovn-kubernetes-mcp, which
+# would otherwise rewrite these objects into the wrong namespace (see nodes.go).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+  - role.yaml
+  - rolebinding.yaml

--- a/config/debug-pod-rbac/role.yaml
+++ b/config/debug-pod-rbac/role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ovnk-mcp-server-debug-pods
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete", "get"]

--- a/config/debug-pod-rbac/rolebinding.yaml
+++ b/config/debug-pod-rbac/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ovnk-mcp-server-debug-pods
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ovnk-mcp-server-debug-pods
+subjects:
+  - kind: ServiceAccount
+    name: ovnk-mcp-server
+    namespace: ovn-kubernetes-mcp

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovnk-mcp-server
+  namespace: ovn-kubernetes-mcp
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ovn-kubernetes-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ovn-kubernetes-mcp
+        app.kubernetes.io/component: mcp-server
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 0
+      serviceAccountName: ovnk-mcp-server
+      containers:
+        - name: ovnk-mcp-server
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          # Default image when applying this manifest as-is. To override at deploy time (e.g. CI or
+          # local kind): use `make deploy-ovnk-mcp-k8s IMAGE=<image>` which patches the image in the deployment.
+          image: localhost/ovnk-mcp-server:dev
+          imagePullPolicy: IfNotPresent
+          args:
+            - --transport=http
+            - --host=0.0.0.0
+            - --port=8080
+            - --mode=live-cluster
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ovn-kubernetes-mcp
+
+resources:
+- namespace.yaml
+- service-account.yaml
+- rbac.yaml
+- deployment.yaml
+- service.yaml
+- networkpolicy.yaml
+
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app.kubernetes.io/component: mcp-server
+    app.kubernetes.io/name: ovn-kubernetes-mcp
+
+images:
+- name: localhost/ovnk-mcp-server
+  newName: localhost/ovnk-mcp-server
+  newTag: dev

--- a/config/namespace.yaml
+++ b/config/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ovn-kubernetes-mcp
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp

--- a/config/networkpolicy.yaml
+++ b/config/networkpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ovnk-mcp-server-deny-ingress
+  namespace: ovn-kubernetes-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ovn-kubernetes-mcp
+      app.kubernetes.io/component: mcp-server
+  policyTypes:
+    - Ingress
+  ingress: []

--- a/config/rbac.yaml
+++ b/config/rbac.yaml
@@ -1,0 +1,40 @@
+# ClusterRole for the OVN-Kubernetes MCP server.
+# It needs read access to cluster resources (for tools that list/get resources).
+# Debug pod permissions in namespace "default" live under config/debug-pod-rbac/
+# (separate kustomization) so kustomize does not rewrite them into ovn-kubernetes-mcp.
+# NOTE: The RBAC rules may need tweaks for running privileged debug pods for
+# some clusters.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovnk-mcp-server
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp
+rules:
+  # Broad read access is intentional: MCP tooling can fetch any resource the user asks for.
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # Pod log access
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  # Pod exec access
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovnk-mcp-server
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ovnk-mcp-server
+subjects:
+  - kind: ServiceAccount
+    name: ovnk-mcp-server
+    namespace: ovn-kubernetes-mcp

--- a/config/service-account.yaml
+++ b/config/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovnk-mcp-server
+  namespace: ovn-kubernetes-mcp
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp

--- a/config/service.yaml
+++ b/config/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ovnk-mcp-server
+  namespace: ovn-kubernetes-mcp
+  labels:
+    app.kubernetes.io/name: ovn-kubernetes-mcp
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: ovn-kubernetes-mcp

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -43,6 +43,18 @@ install_dependencies() {
     npx -v
 }
 
+# install_image accepts the image name along with the tag as an argument and installs it.
+install_image() {
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    # podman: cf https://github.com/kubernetes-sigs/kind/issues/2027
+    rm -f /tmp/image.tar
+    podman save -o /tmp/image.tar "${1}"
+    kind load image-archive /tmp/image.tar --name "${2}"
+  else
+    kind load docker-image "${1}" --name "${2}"
+  fi
+}
+
 install_dependencies
 echo "Dependencies installed"
 
@@ -57,8 +69,128 @@ if [[ "${MCP_MODE}" == "offline" ]]; then
         ginkgo -vv --focus="\[offline\]" test/e2e
     fi
 else
-    echo "Running live-cluster mode tests (excluding offline tests)"
+    # Live-cluster: use Dockerfile and k8s manifests (build image, deploy, port-forward)
+    if [[ -z "${KUBECTL:-}" ]]; then
+        if kubectl_path=$(command -v kubectl 2>/dev/null); then
+            KUBECTL=$kubectl_path
+        else
+            echo "KUBECTL is not set and kubectl was not found in PATH"
+            exit 1
+        fi
+    fi
+    export KUBECTL
+
+    if [[ -z "${KUBECONFIG:-}" ]]; then
+        echo "KUBECONFIG is required for live-cluster mode"
+        exit 1
+    fi
+    if ! command -v kind &>/dev/null; then
+        echo "kind is required for live-cluster mode but was not found. Install it from https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+        exit 1
+    fi
+    GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+    if [[ -z "${GIT_ROOT:-}" ]]; then
+        echo "GIT_ROOT is not set and could not be determined. Run from inside the repo or set GIT_ROOT."
+        exit 1
+    fi
+    cd "$GIT_ROOT" || exit 1
+
+    # Live-cluster e2e targets a kind cluster; infer name from current context (must be kind-<name>).
+    CURRENT_CTX=$("${KUBECTL}" config current-context 2>/dev/null || true)
+    if [[ -z "${CURRENT_CTX}" ]]; then
+        echo "No current kubectl context (KUBECONFIG=${KUBECONFIG}); cannot determine kind cluster name"
+        exit 1
+    fi
+    if [[ "${CURRENT_CTX}" != kind-* ]]; then
+        echo "Current kubectl context must be a kind cluster (expected kind-<name>, got: ${CURRENT_CTX})"
+        exit 1
+    fi
+    KIND_CLUSTER_NAME="${CURRENT_CTX#kind-}"
+    
+    IMAGE="${IMAGE:-localhost/ovnk-mcp-server:dev}"
+    MCP_LOCAL_PORT="${MCP_LOCAL_PORT:-18080}"
+
+    DEPLOY_OVNK_MCP_K8S_INVOKED=0
+    PF_PID=""
+    cleanup() {
+        if [[ -n "${PF_PID:-}" ]] && kill -0 "$PF_PID" 2>/dev/null; then
+            kill "$PF_PID" 2>/dev/null || true
+            wait "$PF_PID" 2>/dev/null || true
+        fi
+        if [[ "${DEPLOY_OVNK_MCP_K8S_INVOKED}" -eq 1 ]]; then
+            make undeploy-ovnk-mcp-k8s || true
+        fi
+    }
+    trap cleanup EXIT
+
+    if [[ -z "${CONTAINER_RUNTIME:-}" ]]; then
+        if command -v podman >/dev/null 2>&1; then
+            CONTAINER_RUNTIME=podman
+        else
+            CONTAINER_RUNTIME=docker
+        fi
+    fi
+    export CONTAINER_RUNTIME
+
+    make build-image IMAGE="$IMAGE" CONTAINER_RUNTIME="$CONTAINER_RUNTIME"
+    install_image "$IMAGE" "$KIND_CLUSTER_NAME"
+    DEPLOY_OVNK_MCP_K8S_INVOKED=1
+    make deploy-ovnk-mcp-k8s IMAGE="$IMAGE"
+
+    # Wait for the deployment to exist (and be Available) before querying namespace/svc/port
+    MCP_LABEL="app.kubernetes.io/name=ovn-kubernetes-mcp"
+    echo "Waiting for MCP server deployment to be Available..."
+    if ! "${KUBECTL}" wait --for=condition=Available deployment -A -l "${MCP_LABEL}" --timeout=60s; then
+        echo "Deployment with label ${MCP_LABEL} did not become Available within 60s"
+        exit 1
+    fi
+
+    # Get namespace, service name, and service port from the cluster (what was actually applied)
+    NAMESPACE=$("${KUBECTL}" get deployment -A -l "${MCP_LABEL}" -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || true)
+    if [[ -z "${NAMESPACE:-}" ]]; then
+        echo "Could not find deployment with label ${MCP_LABEL}; is deploy-ovnk-mcp-k8s applied?"
+        exit 1
+    fi
+    SVC=$("${KUBECTL}" get svc -n "${NAMESPACE}" -l "${MCP_LABEL}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    SVC_PORT=$("${KUBECTL}" get svc -n "${NAMESPACE}" -l "${MCP_LABEL}" -o jsonpath='{.items[0].spec.ports[0].port}' 2>/dev/null || true)
+    if [[ -z "${SVC:-}" || -z "${SVC_PORT:-}" ]]; then
+        echo "Could not find service or port in namespace ${NAMESPACE} with label ${MCP_LABEL}"
+        exit 1
+    fi
+
+    # Wait for pod to be Ready (readiness probe passed) before port-forward so MCP server accepts requests
+    echo "Waiting for MCP server pod to be Ready..."
+    if ! "${KUBECTL}" wait --for=condition=Ready pod -n "$NAMESPACE" -l app.kubernetes.io/name=ovn-kubernetes-mcp --timeout=120s; then
+        echo "MCP server pod did not become Ready within 120s"
+        "${KUBECTL}" get pods -n "$NAMESPACE" -l app.kubernetes.io/name=ovn-kubernetes-mcp 2>/dev/null || true
+        exit 1
+    fi
+
+    "${KUBECTL}" port-forward -n "$NAMESPACE" "svc/${SVC}" "${MCP_LOCAL_PORT}:${SVC_PORT}" &
+    PF_PID=$!
+    # Wait for port-forward to be ready: process alive and server responding.
+    PF_TIMEOUT=30
+    PF_ELAPSED=0
+    while [[ $PF_ELAPSED -lt $PF_TIMEOUT ]]; do
+        if ! kill -0 "$PF_PID" 2>/dev/null; then
+            echo "Port-forward exited unexpectedly"
+            exit 1
+        fi
+        if curl -s -o /dev/null --connect-timeout 2 "http://127.0.0.1:${MCP_LOCAL_PORT}/" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        PF_ELAPSED=$((PF_ELAPSED + 1))
+    done
+    if [[ $PF_ELAPSED -ge $PF_TIMEOUT ]]; then
+        echo "Port-forward did not become ready within ${PF_TIMEOUT}s (http://127.0.0.1:${MCP_LOCAL_PORT} not responding)"
+        exit 1
+    fi
+
+    export MCP_SERVER_URL="http://127.0.0.1:${MCP_LOCAL_PORT}"
     export MCP_MODE="live-cluster"
+
+    echo "Running live-cluster mode tests (excluding offline tests)"
     if [[ -n "${FOCUS}" ]]; then
         ginkgo -vv --skip="\[offline\]" --focus="${FOCUS}" test/e2e
     else

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	mcpServerPathEnvVar = "MCP_SERVER_PATH"
+	mcpServerURLEnvVar  = "MCP_SERVER_URL" // when set (live-cluster), connect via HTTP to deployed server
 	kubeconfigEnvVar    = "KUBECONFIG"
 	mcpModeEnvVar       = "MCP_MODE"
 	mcpModeOffline      = "offline"
@@ -90,13 +91,12 @@ func TestE2e(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	mcpServerPath := os.Getenv(mcpServerPathEnvVar)
-	Expect(mcpServerPath).NotTo(BeEmpty())
-
 	mcpMode := os.Getenv(mcpModeEnvVar)
 	Expect(mcpMode).NotTo(BeEmpty())
 	if mcpMode == mcpModeOffline {
 		// Offline mode - configure MCP inspector without kubeconfig
+		mcpServerPath := os.Getenv(mcpServerPathEnvVar)
+		Expect(mcpServerPath).NotTo(BeEmpty())
 		mcpInspector = inspector.NewMCPInspector().
 			Command(mcpServerPath).
 			CommandFlags(map[string]string{
@@ -105,6 +105,7 @@ var _ = BeforeSuite(func() {
 		return
 	}
 
+	// Live-cluster mode
 	kubeconfig := os.Getenv(kubeconfigEnvVar)
 	Expect(kubeconfig).NotTo(BeEmpty())
 
@@ -115,6 +116,16 @@ var _ = BeforeSuite(func() {
 
 	k8se2eframework.TestContext.KubeConfig = kubeconfig
 
+	mcpServerURL := os.Getenv(mcpServerURLEnvVar)
+	if mcpServerURL != "" {
+		// Connect to MCP server over HTTP (e.g. port-forward to deployment from Dockerfile + k8s manifests)
+		mcpInspector = inspector.NewMCPInspector().URL(mcpServerURL)
+		return
+	}
+
+	// Run MCP server as local binary with kubeconfig
+	mcpServerPath := os.Getenv(mcpServerPathEnvVar)
+	Expect(mcpServerPath).NotTo(BeEmpty())
 	mcpInspector = inspector.NewMCPInspector().
 		Command(mcpServerPath).
 		CommandFlags(map[string]string{

--- a/test/e2e/inspector/mcp_inspector.go
+++ b/test/e2e/inspector/mcp_inspector.go
@@ -15,6 +15,7 @@ const (
 
 type MCPInspector struct {
 	command      string
+	serverURL    string // when set gets priority over command, connect via HTTP
 	methodType   string
 	toolName     string
 	toolArgs     map[string]any
@@ -27,6 +28,13 @@ func NewMCPInspector() *MCPInspector {
 
 func (i *MCPInspector) Command(cmd string) *MCPInspector {
 	i.command = cmd
+	return i
+}
+
+// URL configures the inspector to connect to an MCP server over HTTP at the given URL
+// (e.g. http://127.0.0.1:18080 when using port-forward to a deployed server).
+func (i *MCPInspector) URL(url string) *MCPInspector {
+	i.serverURL = url
 	return i
 }
 
@@ -48,8 +56,8 @@ func (i *MCPInspector) MethodCall(toolName string, toolArgs map[string]any) *MCP
 }
 
 func (i *MCPInspector) Execute() ([]byte, error) {
-	if i.command == "" {
-		return nil, fmt.Errorf("command is required")
+	if i.command == "" && i.serverURL == "" {
+		return nil, fmt.Errorf("command or server URL is required")
 	}
 	if i.methodType == "" {
 		return nil, fmt.Errorf("method is required")
@@ -84,7 +92,12 @@ func (i *MCPInspector) getCmdArgs() (string, []string, error) {
 		"@modelcontextprotocol/inspector",
 		"--cli",
 	}
-	args = append(args, i.command)
+	if i.serverURL != "" {
+		args = append(args, i.serverURL)
+		args = append(args, "--transport", "http")
+	} else {
+		args = append(args, i.command)
+	}
 	args = append(args, "--method")
 	args = append(args, i.methodType)
 	if i.methodType == string(MethodTypeCall) {
@@ -116,7 +129,8 @@ func (i *MCPInspector) getCmdArgs() (string, []string, error) {
 		}
 	}
 
-	if len(i.commandflags) > 0 {
+	// Command flags (e.g. --kubeconfig) only apply when running the server as a subprocess
+	if i.serverURL == "" && len(i.commandflags) > 0 {
 		args = append(args, "--")
 		for key, value := range i.commandflags {
 			args = append(args, fmt.Sprintf("--%s", key))


### PR DESCRIPTION
Fixes #25 
Fixes #44 

This PR adds Dockerfile and kubernetes manifests. The PR also updates the live-cluster e2e test setup so that the test deploys the MCP server in the kind cluster in which the tests are being run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-stage container build and .dockerignore to reduce build context.
  * Kubernetes manifests and kustomize: namespace, service account, RBAC, Deployment, Service, NetworkPolicy; pod runs non-root, exposes HTTP on 8080 with probes and resource limits.
  * Server accepts a configurable bind address via a new --host flag.
  * Debug-pod RBAC kustomization and role/rolebinding for debug pods.

* **Chores**
  * Build/deploy tooling improved: image build/load targets and deploy/undeploy workflows.

* **Tests**
  * E2E harness can target a live HTTP server via MCP_SERVER_URL; inspector supports HTTP transport and live-cluster workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->