### PR TITLE
 e2e test coverage for OVN, OVS, and Network Tools.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
   e2e:
     name: E2E Test Suite
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
   e2e:
     name: E2E Test Suite
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/test/e2e/kernel_test.go
+++ b/test/e2e/kernel_test.go
@@ -1,12 +1,8 @@
 package e2e
 
 import (
-	"context"
+	"maps"
 	"strings"
-	"time"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,7 +12,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/test/e2e/utils"
 )
 
-var _ = Describe("Kernel Tools", func() {
+var _ = Describe("Kernel Tools", Ordered, func() {
 	const (
 		getIPToolName        = "get-ip"
 		getIPTablesToolName  = "get-iptables"
@@ -26,84 +22,17 @@ var _ = Describe("Kernel Tools", func() {
 
 	var nodeName string
 
-	// BeforeEach finds a ready worker node once per test
-	BeforeEach(func() {
-		nodeName = ""
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		nodeList := &corev1.NodeList{}
-		err := kubeClient.List(ctx, nodeList)
-		Expect(err).NotTo(HaveOccurred(), "Failed to list nodes")
-
-		// Look for a ready worker node (not control-plane)
-		for _, node := range nodeList.Items {
-			isReady := false
-			isControlPlane := false
-
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-					isReady = true
-					break
-				}
-			}
-
-			if _, hasLabel := node.Labels["node-role.kubernetes.io/control-plane"]; hasLabel {
-				isControlPlane = true
-			}
-			if _, hasLabel := node.Labels["node-role.kubernetes.io/master"]; hasLabel {
-				isControlPlane = true
-			}
-
-			if isReady && !isControlPlane {
-				nodeName = node.Name
-				return
-			}
-		}
-
-		// If no worker found, use the first ready node
-		for _, node := range nodeList.Items {
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-					nodeName = node.Name
-					return
-				}
-			}
-		}
-
-		Expect(nodeName).NotTo(BeEmpty(), "No ready node found")
+	BeforeAll(func() {
+		var err error
+		nodeName, err = utils.FindReadyNode(kubeClient)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	withNode := func(args map[string]any) map[string]any {
 		toolArgs := make(map[string]any, len(args)+1)
-		for key, value := range args {
-			toolArgs[key] = value
-		}
+		maps.Copy(toolArgs, args)
 		toolArgs["node"] = nodeName
 		return toolArgs
-	}
-
-	expectToolError := func(toolName string, toolArgs map[string]any, wantError string) {
-		output, err := mcpInspector.
-			MethodCall(toolName, toolArgs).
-			Execute()
-		Expect(err).NotTo(HaveOccurred())
-
-		var result mcp.CallToolResult
-		Expect(result.UnmarshalJSON(output)).To(Succeed())
-		Expect(result.IsError).To(BeTrue())
-		Expect(result.Content).NotTo(BeEmpty())
-
-		var messages []string
-		for _, content := range result.Content {
-			textContent, ok := content.(*mcp.TextContent)
-			if ok {
-				messages = append(messages, textContent.Text)
-			}
-		}
-
-		Expect(messages).NotTo(BeEmpty(), "expected error text content in CallToolResult")
-		Expect(strings.Join(messages, "\n")).To(ContainSubstring(wantError))
 	}
 
 	Context("get-ip", func() {
@@ -212,7 +141,7 @@ var _ = Describe("Kernel Tools", func() {
 	Context("validation errors", func() {
 		DescribeTable("should reject invalid kernel tool inputs",
 			func(toolName string, toolArgs map[string]any, wantError string) {
-				expectToolError(toolName, withNode(toolArgs), wantError)
+				utils.ExpectToolError(mcpInspector, toolName, withNode(toolArgs), wantError)
 			},
 			Entry("get-ip invalid command", getIPToolName, map[string]any{
 				"command": "link list",
@@ -239,7 +168,7 @@ var _ = Describe("Kernel Tools", func() {
 
 		DescribeTable("should reject metacharacters in filter parameters",
 			func(toolName string, toolArgs map[string]any) {
-				expectToolError(toolName, withNode(toolArgs), "invalid use of metacharacters in parameter")
+				utils.ExpectToolError(mcpInspector, toolName, withNode(toolArgs), "invalid use of metacharacters in parameter")
 			},
 			Entry("get-ip filter parameters", getIPToolName, map[string]any{
 				"command":           "route show",

--- a/test/e2e/kernel_test.go
+++ b/test/e2e/kernel_test.go
@@ -110,10 +110,9 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve IP routing information from a node", func() {
 			By("Running get-ip to show routes")
 			output, err := mcpInspector.
-				MethodCall(getIPToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getIPToolName, withNode(map[string]any{
 					"command": "route show",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
@@ -130,10 +129,9 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve network interface information from a node", func() {
 			By("Running get-ip to show links")
 			output, err := mcpInspector.
-				MethodCall(getIPToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getIPToolName, withNode(map[string]any{
 					"command": "link show",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
@@ -153,11 +151,10 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve iptables rules from a node", func() {
 			By("Running get-iptables to list filter table rules")
 			output, err := mcpInspector.
-				MethodCall(getIPTablesToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getIPTablesToolName, withNode(map[string]any{
 					"table":   "filter",
 					"command": "-L",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
@@ -175,11 +172,10 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve NAT table rules from a node", func() {
 			By("Running get-iptables to list nat table rules")
 			output, err := mcpInspector.
-				MethodCall(getIPTablesToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getIPTablesToolName, withNode(map[string]any{
 					"table":   "nat",
 					"command": "-L",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
@@ -199,10 +195,9 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve nftables ruleset from a node", func() {
 			By("Running get-nft to list tables")
 			output, err := mcpInspector.
-				MethodCall(getNFTToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getNFTToolName, withNode(map[string]any{
 					"command": "list tables",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
@@ -270,10 +265,9 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve connection tracking list from a node", func() {
 			By("Running get-conntrack to list connections")
 			output, err := mcpInspector.
-				MethodCall(getConntrackToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getConntrackToolName, withNode(map[string]any{
 					"command": "-L",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
@@ -310,10 +304,9 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve connection tracking count from a node", func() {
 			By("Running get-conntrack to count connections")
 			output, err := mcpInspector.
-				MethodCall(getConntrackToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getConntrackToolName, withNode(map[string]any{
 					"command": "-C",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
@@ -327,10 +320,9 @@ var _ = Describe("Kernel Tools", func() {
 		It("should retrieve connection tracking statistics from a node", func() {
 			By("Running get-conntrack to show statistics")
 			output, err := mcpInspector.
-				MethodCall(getConntrackToolName, map[string]any{
-					"node":    nodeName,
+				MethodCall(getConntrackToolName, withNode(map[string]any{
 					"command": "-S",
-				}).Execute()
+				})).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 

--- a/test/e2e/kubernetes_test.go
+++ b/test/e2e/kubernetes_test.go
@@ -3,16 +3,21 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8se2eframework "k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/test/e2e/utils"
 )
@@ -21,152 +26,543 @@ var _ = Describe("Kubernetes Tools", func() {
 	const (
 		resourceGetToolName  = "resource-get"
 		resourceListToolName = "resource-list"
+		podLogsToolName      = "pod-logs"
 	)
 
 	fr := k8se2eframework.NewDefaultFramework("kubernetes-tools")
 
 	Context("Get Resource", func() {
-		It("should get a secret from a namespace", func() {
-			By("Creating a secret")
-			secretName := "test-secret"
-			err := kubeClient.Create(context.Background(), &corev1.Secret{
+		// Replace Secret tests with ConfigMap
+		It("should get a configmap from a namespace", func() {
+			By("Creating a configmap")
+			cmName := "test-configmap"
+			err := kubeClient.Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
+					Name:      cmName,
 					Namespace: fr.Namespace.Name,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Getting the secret")
+			By("Getting the configmap")
 			output, err := mcpInspector.
 				MethodCall(resourceGetToolName, map[string]any{
 					"group":     "",
 					"version":   "v1",
-					"kind":      "Secret",
+					"kind":      "ConfigMap",
 					"namespace": fr.Namespace.Name,
-					"name":      secretName,
+					"name":      cmName,
 				}).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
 			By("Checking the result")
 			getResult := utils.UnmarshalCallToolResult[types.GetResourceResult](output)
-
-			expectedGetResult := types.GetResourceResult{
-				Resource: types.Resource{
-					NamespacedNameResult: types.NamespacedNameResult{
-						Name:      secretName,
-						Namespace: fr.Namespace.Name,
-					},
-				},
-			}
-
-			cmpOptions := cmp.Options{
-				cmpopts.IgnoreFields(types.Resource{}, "Age"),
-				cmpopts.IgnoreFields(types.Resource{}, "Labels"),
-				cmpopts.IgnoreFields(types.Resource{}, "Annotations"),
-				cmpopts.IgnoreFields(types.Resource{}, "FormattedOutput.Data"),
-			}
-			Expect(cmp.Equal(getResult, expectedGetResult, cmpOptions)).To(BeTrue())
+			Expect(getResult.Resource.Name).To(Equal(cmName))
+			Expect(getResult.Resource.Namespace).To(Equal(fr.Namespace.Name))
 		})
 
-		It("should get the data of a secret from a namespace using JSON output type", func() {
-			By("Creating a secret with data")
-			secretName := "test-secret"
-			data := map[string][]byte{
-				"data": []byte("test-data"),
+		It("should get a configmap with JSON output type", func() {
+			By("Creating a configmap with data")
+			cmName := "test-configmap-json"
+			data := map[string]string{
+				"app.conf":  "debug=true",
+				"db.config": "host=localhost",
 			}
-			err := kubeClient.Create(context.Background(), &corev1.Secret{
+			err := kubeClient.Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
+					Name:      cmName,
 					Namespace: fr.Namespace.Name,
 				},
 				Data: data,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Getting the secret")
+			By("Getting the configmap with JSON output")
 			output, err := mcpInspector.
 				MethodCall(resourceGetToolName, map[string]any{
 					"group":       "",
 					"version":     "v1",
-					"kind":        "Secret",
+					"kind":        "ConfigMap",
 					"namespace":   fr.Namespace.Name,
-					"name":        secretName,
+					"name":        cmName,
 					"output_type": string(types.JSONOutputType),
 				}).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
-			By("Checking the data of the secret")
+			By("Verifying the configmap data")
 			getResult := utils.UnmarshalCallToolResult[types.GetResourceResult](output)
-
-			fetchedJSONData := getResult.Resource.Data
-			var fetchedSecret corev1.Secret
-			err = json.Unmarshal([]byte(fetchedJSONData), &fetchedSecret)
+			var fetchedCM corev1.ConfigMap
+			err = json.Unmarshal([]byte(getResult.Resource.Data), &fetchedCM)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(fetchedSecret.Data).To(Equal(data))
+			Expect(fetchedCM.Data).To(Equal(data))
 		})
-	})
 
-	Context("List Resources", func() {
-		It("should list secrets from a namespace", func() {
-			By("Creating 2 secrets")
-			secretName1 := "test-secret-1"
-			secretName2 := "test-secret-2"
-			err := kubeClient.Create(context.Background(), &corev1.Secret{
+		It("should get a pod with jsonTemplate to extract container image", func() {
+			By("Creating a pod")
+			podName := "test-pod"
+			err := kubeClient.Create(context.Background(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName1,
+					Name:      podName,
 					Namespace: fr.Namespace.Name,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "nginx",
+							Image:           "nginx:alpine",
+							SecurityContext: utils.RestrictedSecurityContext(),
+						},
+					},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			err = kubeClient.Create(context.Background(), &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName2,
-					Namespace: fr.Namespace.Name,
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
 
-			By("Listing secrets")
+			By("Getting the pod with jsonTemplate to extract container image")
 			output, err := mcpInspector.
-				MethodCall(resourceListToolName, map[string]any{
-					"group":     "",
-					"version":   "v1",
-					"kind":      "Secret",
-					"namespace": fr.Namespace.Name,
+				MethodCall(resourceGetToolName, map[string]any{
+					"group":       "",
+					"version":     "v1",
+					"kind":        "Pod",
+					"namespace":   fr.Namespace.Name,
+					"name":        podName,
+					"output_type": "jsonpath={.spec.containers[0].image}",
 				}).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
-			By("Checking the result")
+			By("Verifying extracted container image")
+			getResult := utils.UnmarshalCallToolResult[types.GetResourceResult](output)
+			Expect(getResult.Resource.Data).To(ContainSubstring("nginx:alpine"))
+		})
+
+		It("should get a service from a namespace", func() {
+			By("Creating a service")
+			svcName := "test-service"
+			err := kubeClient.Create(context.Background(), &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: fr.Namespace.Name,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "test"},
+					Ports: []corev1.ServicePort{
+						{Port: 80, Protocol: corev1.ProtocolTCP},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the service")
+			output, err := mcpInspector.
+				MethodCall(resourceGetToolName, map[string]any{
+					"group":     "",
+					"version":   "v1",
+					"kind":      "Service",
+					"namespace": fr.Namespace.Name,
+					"name":      svcName,
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Verifying service information")
+			getResult := utils.UnmarshalCallToolResult[types.GetResourceResult](output)
+			Expect(getResult.Resource.Name).To(Equal(svcName))
+		})
+
+		It("should get a deployment with YAML output type", func() {
+			By("Creating a deployment")
+			deployName := "test-deployment"
+			replicas := int32(1)
+			err := kubeClient.Create(context.Background(), &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deployName,
+					Namespace: fr.Namespace.Name,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "test"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:            "nginx",
+									Image:           "nginx:alpine",
+									SecurityContext: utils.RestrictedSecurityContext(),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the deployment with YAML output")
+			output, err := mcpInspector.
+				MethodCall(resourceGetToolName, map[string]any{
+					"group":       "apps",
+					"version":     "v1",
+					"kind":        "Deployment",
+					"namespace":   fr.Namespace.Name,
+					"name":        deployName,
+					"output_type": string(types.YAMLOutputType),
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Verifying YAML output contains correct deployment spec")
+			getResult := utils.UnmarshalCallToolResult[types.GetResourceResult](output)
+
+			var fetchedDeploy appsv1.Deployment
+			err = yaml.Unmarshal([]byte(getResult.Resource.Data), &fetchedDeploy)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fetchedDeploy.Name).To(Equal(deployName))
+			Expect(fetchedDeploy.Namespace).To(Equal(fr.Namespace.Name))
+			Expect(*fetchedDeploy.Spec.Replicas).To(Equal(replicas))
+			Expect(fetchedDeploy.Spec.Selector.MatchLabels).To(Equal(map[string]string{"app": "test"}))
+			Expect(fetchedDeploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(fetchedDeploy.Spec.Template.Spec.Containers[0].Name).To(Equal("nginx"))
+			Expect(fetchedDeploy.Spec.Template.Spec.Containers[0].Image).To(Equal("nginx:alpine"))
+		})
+	})
+
+	Context("List Resources", func() {
+		It("should list configmaps from a namespace", func() {
+			By("Creating 2 configmaps")
+			cm1 := "test-cm-1"
+			cm2 := "test-cm-2"
+			testLabel := map[string]string{"test": "e2e-list-cm"}
+			err := kubeClient.Create(context.Background(), &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cm1,
+					Namespace: fr.Namespace.Name,
+					Labels:    testLabel,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = kubeClient.Create(context.Background(), &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cm2,
+					Namespace: fr.Namespace.Name,
+					Labels:    testLabel,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Listing configmaps with label selector")
+			output, err := mcpInspector.
+				MethodCall(resourceListToolName, map[string]any{
+					"group":          "",
+					"version":        "v1",
+					"kind":           "ConfigMap",
+					"namespace":      fr.Namespace.Name,
+					"label_selector": "test=e2e-list-cm",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Verifying configmaps are listed")
+			listResult := utils.UnmarshalCallToolResult[types.ListResourcesResult](output)
+			Expect(listResult.Resources).To(HaveLen(2))
+			cmNames := make([]string, len(listResult.Resources))
+			for i, resource := range listResult.Resources {
+				cmNames[i] = resource.Name
+			}
+			Expect(cmNames).To(ContainElement(cm1))
+			Expect(cmNames).To(ContainElement(cm2))
+		})
+
+		It("should list resources with label selector", func() {
+			By("Creating configmaps with labels")
+			cm1 := "labeled-cm-1"
+			cm2 := "labeled-cm-2"
+			cm3 := "unlabeled-cm"
+
+			// ConfigMaps with label
+			for _, name := range []string{cm1, cm2} {
+				err := kubeClient.Create(context.Background(), &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: fr.Namespace.Name,
+						Labels:    map[string]string{"env": "test"},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// ConfigMap without label
+			err := kubeClient.Create(context.Background(), &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cm3,
+					Namespace: fr.Namespace.Name,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Listing configmaps with label selector")
+			output, err := mcpInspector.
+				MethodCall(resourceListToolName, map[string]any{
+					"group":          "",
+					"version":        "v1",
+					"kind":           "ConfigMap",
+					"namespace":      fr.Namespace.Name,
+					"label_selector": "env=test",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Verifying only labeled configmaps are returned")
+			listResult := utils.UnmarshalCallToolResult[types.ListResourcesResult](output)
+			Expect(listResult.Resources).To(HaveLen(2))
+			cmNames := make([]string, len(listResult.Resources))
+			for i, resource := range listResult.Resources {
+				cmNames[i] = resource.Name
+			}
+			Expect(cmNames).To(ContainElement(cm1))
+			Expect(cmNames).To(ContainElement(cm2))
+			Expect(cmNames).NotTo(ContainElement(cm3))
+		})
+
+		It("should list pods from a namespace", func() {
+			By("Creating test pods")
+			pod1 := "test-pod-1"
+			pod2 := "test-pod-2"
+			testLabel := map[string]string{"test": "e2e-list-pods"}
+			for _, name := range []string{pod1, pod2} {
+				err := kubeClient.Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: fr.Namespace.Name,
+						Labels:    testLabel,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:            "nginx",
+								Image:           "nginx:alpine",
+								SecurityContext: utils.RestrictedSecurityContext(),
+							},
+						},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Listing pods with label selector (resource-list queries API objects regardless of phase)")
+			// Note: resource-list reads from Kubernetes API and doesn't require pods to be Running.
+			// The tool lists API objects in any phase (Pending/Running/Failed/etc), so no wait needed.
+			output, err := mcpInspector.
+				MethodCall(resourceListToolName, map[string]any{
+					"group":          "",
+					"version":        "v1",
+					"kind":           "Pod",
+					"namespace":      fr.Namespace.Name,
+					"label_selector": "test=e2e-list-pods",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Verifying pods are listed")
+			listResult := utils.UnmarshalCallToolResult[types.ListResourcesResult](output)
+			Expect(listResult.Resources).To(HaveLen(2))
+			podNames := make([]string, len(listResult.Resources))
+			for i, resource := range listResult.Resources {
+				podNames[i] = resource.Name
+			}
+			Expect(podNames).To(ContainElement(pod1))
+			Expect(podNames).To(ContainElement(pod2))
+		})
+
+		It("should list configmaps with JSON output type", func() {
+			By("Creating configmaps with data")
+			cm1 := "test-cm-json-1"
+			cm2 := "test-cm-json-2"
+			testLabel := map[string]string{"test": "e2e-json-cm"}
+
+			for i, name := range []string{cm1, cm2} {
+				err := kubeClient.Create(context.Background(), &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: fr.Namespace.Name,
+						Labels:    testLabel,
+					},
+					Data: map[string]string{
+						"key": fmt.Sprintf("value%d", i+1),
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Listing configmaps with JSON output and label selector")
+			output, err := mcpInspector.
+				MethodCall(resourceListToolName, map[string]any{
+					"group":          "",
+					"version":        "v1",
+					"kind":           "ConfigMap",
+					"namespace":      fr.Namespace.Name,
+					"label_selector": "test=e2e-json-cm",
+					"output_type":    string(types.JSONOutputType),
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Verifying JSON output contains configmap data")
 			listResult := utils.UnmarshalCallToolResult[types.ListResourcesResult](output)
 			Expect(listResult.Resources).To(HaveLen(2))
 
-			expectedListResult := types.ListResourcesResult{
-				Resources: []types.Resource{
-					{
-						NamespacedNameResult: types.NamespacedNameResult{
-							Name:      secretName1,
-							Namespace: fr.Namespace.Name,
-						},
-					},
-					{
-						NamespacedNameResult: types.NamespacedNameResult{
-							Name:      secretName2,
-							Namespace: fr.Namespace.Name,
+			// Each resource should have JSON data - parse and verify
+			var foundNames []string
+			for _, resource := range listResult.Resources {
+				Expect(resource.Data).NotTo(BeEmpty())
+
+				var cm corev1.ConfigMap
+				err = json.Unmarshal([]byte(resource.Data), &cm)
+				Expect(err).NotTo(HaveOccurred())
+				foundNames = append(foundNames, cm.Name)
+			}
+
+			// Verify ConfigMap names are present
+			Expect(foundNames).To(ContainElement(cm1))
+			Expect(foundNames).To(ContainElement(cm2))
+		})
+	})
+
+	Context("Pod Logs", func() {
+		createLoggingPod := func(podName string) {
+			By("Creating a pod that generates logs")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: fr.Namespace.Name,
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "logger",
+							Image:   "busybox:1.36",
+							Command: []string{"/bin/sh", "-c"},
+							Args: []string{
+								"for i in 1 2 3 4 5 6 7 8 9 10; do echo 'Log line '$i; sleep 1; done; sleep 30",
+							},
+							SecurityContext: utils.RestrictedSecurityContext(),
 						},
 					},
 				},
 			}
-			cmpOptions := cmp.Options{
-				cmpopts.IgnoreFields(types.Resource{}, "Age"),
-				cmpopts.IgnoreFields(types.Resource{}, "Labels"),
-				cmpopts.IgnoreFields(types.Resource{}, "Annotations"),
-				cmpopts.IgnoreFields(types.Resource{}, "FormattedOutput.Data"),
+			err := kubeClient.Create(context.Background(), pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for pod to be running")
+			Eventually(func() bool {
+				err := kubeClient.Get(context.Background(), client.ObjectKey{
+					Namespace: fr.Namespace.Name,
+					Name:      podName,
+				}, pod)
+				if err != nil {
+					return false
+				}
+				return pod.Status.Phase == corev1.PodRunning
+			}, 60*time.Second, 2*time.Second).Should(BeTrue())
+		}
+
+		waitForLogs := func(podName string, extraArgs map[string]any, ready ...func(types.GetPodLogsResult) bool) types.GetPodLogsResult {
+			args := map[string]any{
+				"namespace": fr.Namespace.Name,
+				"name":      podName,
 			}
-			Expect(cmp.Equal(listResult, expectedListResult, cmpOptions)).To(BeTrue())
+			maps.Copy(args, extraArgs)
+			check := func(r types.GetPodLogsResult) bool { return len(r.Logs) > 0 }
+			if len(ready) > 0 && ready[0] != nil {
+				check = ready[0]
+			}
+			var result types.GetPodLogsResult
+			Eventually(func() bool {
+				output, err := mcpInspector.
+					MethodCall(podLogsToolName, args).Execute()
+				if err != nil || len(output) == 0 {
+					return false
+				}
+				result = utils.UnmarshalCallToolResult[types.GetPodLogsResult](output)
+				return check(result)
+			}, 30*time.Second, 2*time.Second).Should(BeTrue())
+			return result
+		}
+
+		It("should get logs from a running pod", func() {
+			podName := "logging-pod"
+			createLoggingPod(podName)
+
+			By("Waiting for logs to be available")
+			logsResult := waitForLogs(podName, nil)
+
+			By("Verifying logs are returned")
+			Expect(logsResult.Logs).NotTo(BeEmpty())
 		})
+
+		It("should get logs with tail parameter", func() {
+			podName := "tail-logs-pod"
+			createLoggingPod(podName)
+
+			By("Waiting for all log lines to be generated")
+			tailResult := waitForLogs(podName, map[string]any{"tail": 5}, func(r types.GetPodLogsResult) bool {
+				return len(r.Logs) == 5 && strings.Contains(r.Logs[len(r.Logs)-1], "Log line 10")
+			})
+
+			By("Verifying tail returns the last 5 lines")
+			Expect(len(tailResult.Logs)).To(Equal(5))
+			Expect(tailResult.Logs[len(tailResult.Logs)-1]).To(ContainSubstring("Log line 10"))
+			Expect(tailResult.Logs[0]).NotTo(ContainSubstring("Log line 1"))
+		})
+	})
+
+	Context("validation errors", func() {
+		DescribeTable("should reject invalid Kubernetes tool inputs",
+			func(toolName string, toolArgs map[string]any, wantError string) {
+				utils.ExpectToolError(mcpInspector, toolName, toolArgs, wantError)
+			},
+			Entry("resource-get missing version", resourceGetToolName, map[string]any{
+				"kind": "ConfigMap",
+				"name": "test",
+			}, "version"),
+			Entry("resource-get missing kind", resourceGetToolName, map[string]any{
+				"version": "v1",
+				"name":    "test",
+			}, "kind"),
+			Entry("resource-get missing name", resourceGetToolName, map[string]any{
+				"version": "v1",
+				"kind":    "ConfigMap",
+			}, "name"),
+			Entry("resource-get invalid output_type", resourceGetToolName, map[string]any{
+				"version":     "v1",
+				"kind":        "ConfigMap",
+				"name":        "test",
+				"output_type": "invalid_format",
+			}, "invalid output_type"),
+			Entry("resource-get invalid jsonpath template", resourceGetToolName, map[string]any{
+				"version":     "v1",
+				"kind":        "ConfigMap",
+				"name":        "test",
+				"output_type": "jsonpath={.invalid[[",
+			}, "invalid json_path_template"),
+			Entry("resource-list missing version", resourceListToolName, map[string]any{
+				"kind": "ConfigMap",
+			}, "version"),
+			Entry("resource-list missing kind", resourceListToolName, map[string]any{
+				"version": "v1",
+			}, "kind"),
+			Entry("resource-list invalid output_type", resourceListToolName, map[string]any{
+				"version":     "v1",
+				"kind":        "ConfigMap",
+				"output_type": "invalid_format",
+			}, "invalid output_type"),
+		)
 	})
 })

--- a/test/e2e/network_tools_test.go
+++ b/test/e2e/network_tools_test.go
@@ -1,0 +1,296 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8se2eframework "k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/network-tools/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/test/e2e/utils"
+)
+
+var _ = Describe("Network Tools", Ordered, func() {
+	const tcpdumpToolName = "tcpdump"
+
+	fr := k8se2eframework.NewDefaultFramework("network-tools")
+
+	var nodeName string
+
+	BeforeAll(func() {
+		var err error
+		nodeName, err = utils.FindReadyNode(kubeClient)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	callTcpdump := func(args map[string]any) types.CommandResult {
+		toolArgs := make(map[string]any, len(args)+1)
+		maps.Copy(toolArgs, args)
+		toolArgs["timeout_seconds"] = 30
+		var result types.CommandResult
+		var lastErr string
+		Eventually(func() bool {
+			output, err := mcpInspector.
+				MethodCall(tcpdumpToolName, toolArgs).Execute()
+			if err != nil {
+				lastErr = fmt.Sprintf("execute error: %v", err)
+				return false
+			}
+			if len(output) == 0 {
+				lastErr = "empty output from MCP server"
+				return false
+			}
+			var callResult mcp.CallToolResult
+			if err := callResult.UnmarshalJSON(output); err != nil {
+				lastErr = fmt.Sprintf("unmarshal error: %v", err)
+				return false
+			}
+			if callResult.IsError {
+				lastErr = fmt.Sprintf("tool returned error: %s", string(output))
+				return false
+			}
+			result = utils.UnmarshalCallToolResult[types.CommandResult](output)
+			return result.Output != ""
+		}, 120*time.Second, 10*time.Second).Should(BeTrue(),
+			fmt.Sprintf("tcpdump never returned successfully; last error: %s", lastErr))
+		return result
+	}
+
+	createServerPod := func(name string) string {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: fr.Namespace.Name,
+			},
+			Spec: corev1.PodSpec{
+				NodeName: nodeName,
+				Containers: []corev1.Container{
+					{
+						Name:            "server",
+						Image:           "busybox:1.36",
+						Command:         []string{"/bin/sh", "-c", "mkdir -p /tmp/www && echo ok > /tmp/www/index.html && httpd -f -p 8080 -h /tmp/www"},
+						Ports:           []corev1.ContainerPort{{ContainerPort: 8080}},
+						SecurityContext: utils.RestrictedSecurityContext(),
+					},
+				},
+			},
+		}
+		err := kubeClient.Create(context.Background(), pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			err := kubeClient.Get(context.Background(), client.ObjectKey{
+				Namespace: fr.Namespace.Name,
+				Name:      name,
+			}, pod)
+			if err != nil {
+				return false
+			}
+			return pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != ""
+		}, 60*time.Second, 2*time.Second).Should(BeTrue())
+
+		return pod.Status.PodIP
+	}
+
+	generateTraffic := func(serverIP string) {
+		clientPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "traffic-client",
+				Namespace: fr.Namespace.Name,
+			},
+			Spec: corev1.PodSpec{
+				NodeName:      nodeName,
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{
+					{
+						Name:            "client",
+						Image:           "busybox:1.36",
+						Command:         []string{"/bin/sh", "-c", fmt.Sprintf("while true; do wget -q -T 2 -O /dev/null http://%s/ 2>/dev/null; sleep 1; done", net.JoinHostPort(serverIP, "8080"))},
+						SecurityContext: utils.RestrictedSecurityContext(),
+					},
+				},
+			},
+		}
+		err := kubeClient.Create(context.Background(), clientPod)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			err := kubeClient.Get(context.Background(), client.ObjectKey{
+				Namespace: fr.Namespace.Name,
+				Name:      "traffic-client",
+			}, clientPod)
+			if err != nil {
+				return false
+			}
+			return clientPod.Status.Phase == corev1.PodRunning
+		}, 60*time.Second, 2*time.Second).Should(BeTrue())
+	}
+
+	Context("tcpdump", func() {
+		var serverIP string
+
+		BeforeEach(func() {
+			By("Creating a server pod")
+			serverIP = createServerPod("tcpdump-server")
+
+			By("Generating pod-to-pod traffic")
+			generateTraffic(serverIP)
+		})
+
+		AfterEach(func() {
+			for _, name := range []string{"tcpdump-server", "traffic-client"} {
+				Expect(client.IgnoreNotFound(kubeClient.Delete(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: fr.Namespace.Name},
+				}))).NotTo(HaveOccurred())
+			}
+			for _, name := range []string{"tcpdump-server", "traffic-client"} {
+				podName := name
+				Eventually(func() bool {
+					err := kubeClient.Get(context.Background(), client.ObjectKey{
+						Namespace: fr.Namespace.Name,
+						Name:      podName,
+					}, &corev1.Pod{})
+					return client.IgnoreNotFound(err) == nil && err != nil
+				}, 60*time.Second, 2*time.Second).Should(BeTrue(),
+					"timed out waiting for pod %s to be deleted", podName)
+			}
+		})
+
+		It("should capture pod-to-pod traffic", func() {
+			By("Running tcpdump to capture network traffic")
+			result := callTcpdump(map[string]any{
+				"target_type":  "node",
+				"name":         nodeName,
+				"packet_count": 5,
+				"interface":    "any",
+				"bpf_filter":   fmt.Sprintf("host %s and port 8080", serverIP),
+			})
+
+			By("Verifying tcpdump captured traffic")
+			Expect(result.Output).NotTo(BeEmpty())
+			Expect(result.Output).To(ContainSubstring(serverIP))
+		})
+
+		It("should capture traffic with BPF filter", func() {
+			By("Running tcpdump with TCP filter")
+			result := callTcpdump(map[string]any{
+				"target_type":  "node",
+				"name":         nodeName,
+				"packet_count": 5,
+				"interface":    "any",
+				"bpf_filter":   fmt.Sprintf("tcp and host %s and port 8080", serverIP),
+			})
+
+			By("Verifying tcpdump BPF filter output")
+			Expect(result.Output).NotTo(BeEmpty())
+			Expect(result.Output).To(ContainSubstring(serverIP))
+			Expect(strings.ToLower(result.Output)).To(ContainSubstring("tcp"))
+		})
+
+		It("should respect packet_count limit", func() {
+			By("Running tcpdump with packet_count=2")
+			result := callTcpdump(map[string]any{
+				"target_type":  "node",
+				"name":         nodeName,
+				"packet_count": 2,
+				"interface":    "any",
+				"bpf_filter":   fmt.Sprintf("host %s and port 8080", serverIP),
+				"snaplen":      128,
+			})
+
+			By("Verifying packet_count=2 limits the number of captured packets")
+			Expect(result.Output).NotTo(BeEmpty())
+			Expect(result.Output).To(ContainSubstring(serverIP))
+			packetLineRe := regexp.MustCompile(`^\d{2}:\d{2}:\d{2}\.\d+ IP`)
+			var packetLines []string
+			for _, line := range strings.Split(strings.TrimSpace(result.Output), "\n") {
+				if packetLineRe.MatchString(line) {
+					packetLines = append(packetLines, line)
+				}
+			}
+			Expect(len(packetLines)).To(BeNumerically("<=", 2),
+				"packet_count=2 should produce at most 2 captured packet lines")
+		})
+	})
+
+	Context("validation errors", func() {
+		DescribeTable("should reject invalid tcpdump inputs",
+			func(toolArgs map[string]any, wantError string) {
+				utils.ExpectToolError(mcpInspector, tcpdumpToolName, toolArgs, wantError)
+			},
+			Entry("missing target_type", map[string]any{
+				"name": "some-node",
+			}, "target_type"),
+			Entry("invalid target_type", map[string]any{
+				"target_type": "invalid",
+				"name":        "some-node",
+			}, "target_type"),
+			Entry("missing name", map[string]any{
+				"target_type": "node",
+			}, "name"),
+			Entry("pod without namespace", map[string]any{
+				"target_type": "pod",
+				"name":        "some-pod",
+			}, "namespace is required"),
+			Entry("invalid interface name", map[string]any{
+				"target_type": "node",
+				"name":        "some-node",
+				"interface":   "eth0; rm -rf /",
+			}, "invalid interface name"),
+			Entry("packet_count exceeds max", map[string]any{
+				"target_type":  "node",
+				"name":         "some-node",
+				"packet_count": 9999,
+			}, "packet_count cannot exceed"),
+			Entry("snaplen exceeds max", map[string]any{
+				"target_type": "node",
+				"name":        "some-node",
+				"snaplen":     9999,
+			}, "snaplen cannot exceed"),
+			Entry("negative packet_count", map[string]any{
+				"target_type":  "node",
+				"name":         "some-node",
+				"packet_count": -1,
+			}, "packet_count cannot be negative"),
+			Entry("negative snaplen", map[string]any{
+				"target_type": "node",
+				"name":        "some-node",
+				"snaplen":     -1,
+			}, "snaplen cannot be negative"),
+			Entry("interface name too long", map[string]any{
+				"target_type": "node",
+				"name":        "some-node",
+				"interface":   "abcdefghijklmnop",
+			}, "interface name too long"),
+			Entry("bpf_filter too long", map[string]any{
+				"target_type": "node",
+				"name":        "some-node",
+				"bpf_filter":  strings.Repeat("a", 1025),
+			}, "packet filter too long"),
+		)
+
+		DescribeTable("should reject metacharacters in filters",
+			func(toolName string, toolArgs map[string]any) {
+				utils.ExpectToolError(mcpInspector, toolName, toolArgs, "invalid use of metacharacters")
+			},
+			Entry("tcpdump bpf_filter", tcpdumpToolName, map[string]any{
+				"target_type": "node",
+				"name":        "some-node",
+				"bpf_filter":  "tcp; rm -rf /",
+			}),
+		)
+	})
+
+})

--- a/test/e2e/ovn_test.go
+++ b/test/e2e/ovn_test.go
@@ -1,10 +1,8 @@
 package e2e
 
 import (
-	"context"
-
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"maps"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,44 +11,25 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/test/e2e/utils"
 )
 
-var _ = Describe("OVN Tools", func() {
+var _ = Describe("OVN Tools", Ordered, func() {
 	const (
-		ovnShowToolName = "ovn-show"
+		ovnShowToolName      = "ovn-show"
+		ovnGetToolName       = "ovn-get"
+		ovnLflowListToolName = "ovn-lflow-list"
+		ovnTraceToolName     = "ovn-trace"
 	)
 
-	// Common OVN-Kubernetes namespaces to search for ovnkube-node pods
-	var ovnNamespaces = []string{
-		"openshift-ovn-kubernetes",
-		"ovn-kubernetes",
-	}
+	var namespace, podName string
 
-	// findOVNKubeNodePod finds a running ovnkube-node pod
-	findOVNKubeNodePod := func() (namespace, name string) {
-		for _, ns := range ovnNamespaces {
-			podList := &corev1.PodList{}
-			err := kubeClient.List(context.Background(), podList,
-				client.InNamespace(ns),
-				client.MatchingLabels{"app": "ovnkube-node"},
-			)
-			if err != nil {
-				continue
-			}
-			for _, pod := range podList.Items {
-				if pod.Status.Phase == corev1.PodRunning {
-					return ns, pod.Name
-				}
-			}
-		}
-		return "", ""
-	}
+	BeforeAll(func() {
+		By("Finding an ovnkube-node pod")
+		var err error
+		namespace, podName, err = utils.FindOVNKubeNodePod(kubeClient)
+		Expect(err).NotTo(HaveOccurred(), "Failed to find ovnkube-node pod")
+	})
 
 	Context("OVN Show", func() {
 		It("should show OVN Northbound database configuration", func() {
-			By("Finding an ovnkube-node pod")
-			namespace, podName := findOVNKubeNodePod()
-			Expect(namespace).NotTo(BeEmpty(), "No running ovnkube-node pod found")
-			Expect(podName).NotTo(BeEmpty(), "No running ovnkube-node pod found")
-
 			By("Running ovn-show for NBDB")
 			output, err := mcpInspector.
 				MethodCall(ovnShowToolName, map[string]any{
@@ -65,7 +44,8 @@ var _ = Describe("OVN Tools", func() {
 			showResult := utils.UnmarshalCallToolResult[types.ShowResult](output)
 			Expect(showResult.Database).To(Equal(types.NorthboundDB))
 			Expect(showResult.Output).NotTo(BeEmpty())
-			// NBDB show output typically contains "switch" for logical switches
+
+			By("Verifying NBDB output contains expected content")
 			Expect(showResult.Output).To(Or(
 				ContainSubstring("switch"),
 				ContainSubstring("router"),
@@ -73,11 +53,6 @@ var _ = Describe("OVN Tools", func() {
 		})
 
 		It("should show OVN Southbound database configuration", func() {
-			By("Finding an ovnkube-node pod")
-			namespace, podName := findOVNKubeNodePod()
-			Expect(namespace).NotTo(BeEmpty(), "No running ovnkube-node pod found")
-			Expect(podName).NotTo(BeEmpty(), "No running ovnkube-node pod found")
-
 			By("Running ovn-show for SBDB")
 			output, err := mcpInspector.
 				MethodCall(ovnShowToolName, map[string]any{
@@ -92,8 +67,145 @@ var _ = Describe("OVN Tools", func() {
 			showResult := utils.UnmarshalCallToolResult[types.ShowResult](output)
 			Expect(showResult.Database).To(Equal(types.SouthboundDB))
 			Expect(showResult.Output).NotTo(BeEmpty())
-			// SBDB show output typically contains "Chassis" information
+
+			By("Verifying SBDB output contains expected content")
 			Expect(showResult.Output).To(ContainSubstring("Chassis"))
 		})
+	})
+
+	Context("OVN Get", func() {
+		It("should get Logical_Switch records from NBDB", func() {
+			By("Running ovn-get for Logical_Switch table")
+			output, err := mcpInspector.
+				MethodCall(ovnGetToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"database":  "nbdb",
+					"table":     "Logical_Switch",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains logical switch records")
+			getResult := utils.UnmarshalCallToolResult[types.GetResult](output)
+			Expect(getResult.Database).To(Equal(types.NorthboundDB))
+			Expect(getResult.Table).To(Equal("Logical_Switch"))
+			Expect(getResult.Output).NotTo(BeEmpty())
+
+			By("Verifying logical switch records output")
+			Expect(getResult.Output).To(Or(
+				ContainSubstring("external_ids"),
+				ContainSubstring("name"),
+				ContainSubstring("_uuid"),
+			))
+		})
+	})
+
+	Context("OVN Lflow List", func() {
+		It("should list logical flows from SBDB", func() {
+			By("Running ovn-lflow-list")
+			output, err := mcpInspector.
+				MethodCall(ovnLflowListToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"head":      50,
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains logical flows within the head limit")
+			lflowResult := utils.UnmarshalCallToolResult[types.LogicalFlowListResult](output)
+			Expect(lflowResult.Flows).NotTo(BeEmpty())
+			Expect(len(lflowResult.Flows)).To(BeNumerically("<=", 50))
+
+			By("Verifying logical flows output")
+			flowToCheck := lflowResult.Flows[0]
+			if len(lflowResult.Flows) > 1 && !strings.Contains(lflowResult.Flows[0], "table=") {
+				flowToCheck = lflowResult.Flows[1]
+			}
+			Expect(flowToCheck).To(Or(
+				ContainSubstring("table="),
+				ContainSubstring("priority="),
+				ContainSubstring("action="),
+			))
+		})
+	})
+
+	Context("OVN Trace", func() {
+		It("should trace a packet through the logical network", func() {
+			By("Running ovn-trace with a simple microflow")
+			output, err := mcpInspector.
+				MethodCall(ovnTraceToolName, map[string]any{
+					"namespace":  namespace,
+					"name":       podName,
+					"datapath":   "join", // Use the join switch which should exist
+					"microflow":  "eth.src==00:00:00:00:00:01 && eth.dst==00:00:00:00:00:02",
+					"mode":       "summary",
+					"head":       30,
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains trace information")
+			traceResult := utils.UnmarshalCallToolResult[types.OVNTraceResult](output)
+			Expect(traceResult.Datapath).To(Equal("join"))
+			Expect(traceResult.Output).NotTo(BeEmpty())
+
+			By("Verifying trace output")
+			Expect(traceResult.Output).To(Or(
+				ContainSubstring("ingress"),
+				ContainSubstring("egress"),
+				ContainSubstring("output"),
+			))
+		})
+	})
+
+	withPod := func(args map[string]any) map[string]any {
+		toolArgs := make(map[string]any, len(args)+2)
+		maps.Copy(toolArgs, args)
+		toolArgs["namespace"] = namespace
+		toolArgs["name"] = podName
+		return toolArgs
+	}
+
+	Context("validation errors", func() {
+		DescribeTable("should reject invalid OVN tool inputs",
+			func(toolName string, toolArgs map[string]any, wantError string) {
+				utils.ExpectToolError(mcpInspector, toolName, withPod(toolArgs), wantError)
+			},
+			Entry("ovn-show invalid database", ovnShowToolName, map[string]any{
+				"database": "invalid_db",
+			}, "invalid database"),
+			Entry("ovn-get invalid database", ovnGetToolName, map[string]any{
+				"database": "invalid_db",
+				"table":    "Logical_Switch",
+			}, "invalid database"),
+			Entry("ovn-get invalid table name", ovnGetToolName, map[string]any{
+				"database": "nbdb",
+				"table":    "123_Invalid",
+			}, "invalid table name"),
+		)
+
+		DescribeTable("should reject metacharacters in OVN tool parameters",
+			func(toolName string, toolArgs map[string]any) {
+				utils.ExpectToolError(mcpInspector, toolName, withPod(toolArgs), "invalid use of metacharacters in parameter")
+			},
+			Entry("ovn-get columns with metacharacters", ovnGetToolName, map[string]any{
+				"database": "nbdb",
+				"table":    "Logical_Switch",
+				"columns":  "name; drop",
+			}),
+			Entry("ovn-lflow-list datapath with metacharacters", ovnLflowListToolName, map[string]any{
+				"datapath": "join | true",
+			}),
+			Entry("ovn-trace datapath with metacharacters", ovnTraceToolName, map[string]any{
+				"datapath":  "join; true",
+				"microflow": "eth.src==00:00:00:00:00:01",
+			}),
+			Entry("ovn-trace microflow with metacharacters", ovnTraceToolName, map[string]any{
+				"datapath":  "join",
+				"microflow": "eth.src==00:00:00:00:00:01 | drop",
+			}),
+		)
 	})
 })

--- a/test/e2e/ovs_test.go
+++ b/test/e2e/ovs_test.go
@@ -1,0 +1,274 @@
+package e2e
+
+import (
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovs/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/test/e2e/utils"
+)
+
+var _ = Describe("OVS Tools", Ordered, func() {
+	const (
+		ovsVsctlToolName  = "ovs-vsctl"
+		ovsOfctlToolName  = "ovs-ofctl"
+		ovsAppctlToolName = "ovs-appctl"
+	)
+
+	var namespace, podName string
+
+	BeforeAll(func() {
+		By("Finding an ovnkube-node pod")
+		var err error
+		namespace, podName, err = utils.FindOVNKubeNodePod(kubeClient)
+		Expect(err).NotTo(HaveOccurred(), "Failed to find ovnkube-node pod")
+	})
+
+	Context("OVS List Bridges", func() {
+		It("should list OVS bridges", func() {
+			By("Running ovs-vsctl list-br")
+			output, err := mcpInspector.
+				MethodCall(ovsVsctlToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"action":    "list-br",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains bridge information")
+			result := utils.UnmarshalCallToolResult[types.VsctlResult](output)
+			Expect(result.Bridges).NotTo(BeEmpty())
+
+			By("Verifying OVS bridges output")
+			bridgeNames := strings.Join(result.Bridges, " ")
+			Expect(bridgeNames).To(And(
+				ContainSubstring("br-int"),
+				Or(
+					ContainSubstring("br-ex"),
+					ContainSubstring("breth0"),
+				),
+			))
+		})
+	})
+
+	Context("OVS List Ports", func() {
+		It("should list OVS ports for br-int bridge", func() {
+			By("Running ovs-vsctl list-ports for br-int")
+			output, err := mcpInspector.
+				MethodCall(ovsVsctlToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"action":    "list-ports",
+					"bridge":    "br-int",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains port information")
+			result := utils.UnmarshalCallToolResult[types.VsctlResult](output)
+			Expect(result.Ports).NotTo(BeEmpty())
+
+			By("Verifying OVS ports output")
+			portNames := strings.Join(result.Ports, " ")
+			Expect(portNames).To(Or(
+				ContainSubstring("patch"),
+				ContainSubstring("ovn-k8s-mp0"),
+				MatchRegexp(`[a-f0-9]{15}`),
+			))
+		})
+	})
+
+	Context("OVS List Interfaces", func() {
+		It("should list OVS interfaces for br-int bridge", func() {
+			By("Running ovs-vsctl list-ifaces for br-int")
+			output, err := mcpInspector.
+				MethodCall(ovsVsctlToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"action":    "list-ifaces",
+					"bridge":    "br-int",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains interface information")
+			result := utils.UnmarshalCallToolResult[types.VsctlResult](output)
+			Expect(result.Interfaces).NotTo(BeNil())
+			Expect(result.Interfaces).NotTo(BeEmpty())
+
+			By("Verifying OVS interfaces output")
+			interfaceNames := strings.Join(result.Interfaces, " ")
+			Expect(interfaceNames).To(Or(
+				ContainSubstring("br-int"),
+				ContainSubstring("patch"),
+				ContainSubstring("genev"),
+			))
+		})
+	})
+
+	Context("OVS Vsctl Show", func() {
+		It("should show OVS database configuration", func() {
+			By("Running ovs-vsctl show")
+			output, err := mcpInspector.
+				MethodCall(ovsVsctlToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"action":    "show",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains OVS configuration")
+			result := utils.UnmarshalCallToolResult[types.VsctlResult](output)
+			Expect(result.Output).NotTo(BeEmpty())
+
+			By("Verifying OVS vsctl show output")
+			Expect(result.Output).To(And(
+				ContainSubstring("Bridge"),
+				ContainSubstring("Port"),
+				ContainSubstring("Interface"),
+			))
+		})
+	})
+
+	Context("OVS Ofctl Dump Flows", func() {
+		It("should dump OpenFlow flows for br-int", func() {
+			By("Running ovs-ofctl dump-flows for br-int")
+			var flowResult types.OfctlResult
+			Eventually(func() bool {
+				output, err := mcpInspector.
+					MethodCall(ovsOfctlToolName, map[string]any{
+						"namespace": namespace,
+						"name":      podName,
+						"action":    "dump-flows",
+						"bridge":    "br-int",
+						"head":      5,
+					}).Execute()
+				if err != nil || len(output) == 0 {
+					return false
+				}
+				var callResult mcp.CallToolResult
+				if callResult.UnmarshalJSON(output) != nil || callResult.IsError {
+					return false
+				}
+				flowResult = utils.UnmarshalCallToolResult[types.OfctlResult](output)
+				return len(flowResult.Flows) > 0
+			}, 30*time.Second, 5*time.Second).Should(BeTrue())
+
+			By("Checking the result contains OpenFlow rules within the head limit")
+			Expect(flowResult.Bridge).To(Equal("br-int"))
+			Expect(len(flowResult.Flows)).To(BeNumerically("<=", 5))
+			Expect(flowResult.Flows).NotTo(BeEmpty())
+
+			By("Verifying OpenFlow flows output")
+			foundValidFlow := false
+			for _, flow := range flowResult.Flows {
+				if strings.Contains(flow, "table=") && strings.Contains(flow, "priority=") && strings.Contains(flow, "actions=") {
+					foundValidFlow = true
+					break
+				}
+			}
+			Expect(foundValidFlow).To(BeTrue(), "Expected at least one flow to contain table=, priority=, and actions= markers")
+		})
+	})
+
+	Context("OVS Appctl Dump Conntrack", func() {
+		It("should dump connection tracking entries", func() {
+			By("Running ovs-appctl dpctl/dump-conntrack")
+			output, err := mcpInspector.
+				MethodCall(ovsAppctlToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"action":    "dpctl/dump-conntrack",
+					"head":      30,
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains conntrack information")
+			result := utils.UnmarshalCallToolResult[types.AppctlResult](output)
+			Expect(result.Entries).NotTo(BeEmpty())
+
+		})
+	})
+
+	Context("OVS Appctl Ofproto Trace", func() {
+		It("should trace packet through OpenFlow pipeline", func() {
+			By("Running ovs-appctl ofproto/trace")
+			output, err := mcpInspector.
+				MethodCall(ovsAppctlToolName, map[string]any{
+					"namespace": namespace,
+					"name":      podName,
+					"action":    "ofproto/trace",
+					"bridge":    "br-int",
+					"flow":      "in_port=1,dl_src=00:00:00:00:00:01,dl_dst=00:00:00:00:00:02",
+					"head":      50,
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains trace information")
+			result := utils.UnmarshalCallToolResult[types.AppctlResult](output)
+			Expect(result.Bridge).To(Equal("br-int"))
+			Expect(result.Output).NotTo(BeEmpty())
+
+			By("Verifying ofproto trace output")
+			Expect(result.Output).To(Or(
+				ContainSubstring("Flow:"),
+				ContainSubstring("Rule:"),
+				ContainSubstring("OpenFlow"),
+			))
+		})
+	})
+
+	withPod := func(args map[string]any) map[string]any {
+		toolArgs := make(map[string]any, len(args)+2)
+		maps.Copy(toolArgs, args)
+		toolArgs["namespace"] = namespace
+		toolArgs["name"] = podName
+		return toolArgs
+	}
+
+	Context("validation errors", func() {
+		DescribeTable("should reject invalid OVS tool inputs",
+			func(toolName string, toolArgs map[string]any, wantError string) {
+				utils.ExpectToolError(mcpInspector, toolName, withPod(toolArgs), wantError)
+			},
+			Entry("ovs-vsctl list-ports invalid bridge", ovsVsctlToolName, map[string]any{
+				"action": "list-ports",
+				"bridge": "br-int; drop",
+			}, "invalid bridge name"),
+			Entry("ovs-vsctl list-ifaces invalid bridge", ovsVsctlToolName, map[string]any{
+				"action": "list-ifaces",
+				"bridge": "br-int; drop",
+			}, "invalid bridge name"),
+			Entry("ovs-ofctl dump-flows invalid bridge", ovsOfctlToolName, map[string]any{
+				"action": "dump-flows",
+				"bridge": "br-int; drop",
+			}, "invalid bridge name"),
+			Entry("ovs-appctl ofproto/trace invalid bridge", ovsAppctlToolName, map[string]any{
+				"action": "ofproto/trace",
+				"bridge": "br-int; drop",
+				"flow":   "in_port=1",
+			}, "invalid bridge name"),
+		)
+
+		DescribeTable("should reject metacharacters in OVS tool parameters",
+			func(toolName string, toolArgs map[string]any) {
+				utils.ExpectToolError(mcpInspector, toolName, withPod(toolArgs), "invalid use of metacharacters in parameter")
+			},
+			Entry("ovs-appctl ofproto/trace flow with metacharacters", ovsAppctlToolName, map[string]any{
+				"action": "ofproto/trace",
+				"bridge": "br-int",
+				"flow":   "in_port=1,dl_src=00:00:00:00:00:01; drop",
+			}),
+		)
+	})
+})

--- a/test/e2e/utils/pod_discovery.go
+++ b/test/e2e/utils/pod_discovery.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var OVNKubeNamespaces = []string{
+	"openshift-ovn-kubernetes",
+	"ovn-kubernetes",
+}
+
+func FindReadyNode(kubeClient client.Client) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	nodeList := &corev1.NodeList{}
+	if err := kubeClient.List(ctx, nodeList); err != nil {
+		return "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	for _, node := range nodeList.Items {
+		isReady := false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				isReady = true
+				break
+			}
+		}
+		if !isReady {
+			continue
+		}
+		if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+			continue
+		}
+		if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
+			continue
+		}
+		return node.Name, nil
+	}
+
+	for _, node := range nodeList.Items {
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				return node.Name, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no ready node found")
+}
+
+func FindOVNKubeNodePod(kubeClient client.Client) (namespace, name string, err error) {
+	ctx := context.Background()
+
+	var foundNS, foundName string
+	var lastErr error
+
+	pollErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		for _, ns := range OVNKubeNamespaces {
+			podList := &corev1.PodList{}
+			if err := kubeClient.List(ctx, podList,
+				client.InNamespace(ns),
+				client.MatchingLabels{"app": "ovnkube-node"},
+			); err != nil {
+				lastErr = err
+				continue
+			}
+			for _, pod := range podList.Items {
+				if pod.Status.Phase != corev1.PodRunning {
+					continue
+				}
+				for _, c := range pod.Status.Conditions {
+					if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+						foundNS = ns
+						foundName = pod.Name
+						return true, nil
+					}
+				}
+			}
+		}
+		return false, nil
+	})
+	if pollErr != nil {
+		if lastErr != nil {
+			return "", "", fmt.Errorf("pod discovery timed out, last error: %w", lastErr)
+		}
+		return "", "", fmt.Errorf("no running ovnkube-node pod found")
+	}
+	return foundNS, foundName, nil
+}

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -5,10 +5,14 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/test/e2e/inspector"
 )
 
 func UnmarshalCallToolResult[T any](output []byte) T {
@@ -25,6 +29,59 @@ func UnmarshalCallToolResult[T any](output []byte) T {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	return resultInTFormat
+}
+
+// ExecuteToolCall runs a tool call and returns the output. It tolerates a non-nil
+// error from Execute() as long as stdout was captured — the MCP inspector CLI exits
+// non-zero when a tool returns isError:true, but stdout still contains the JSON response.
+func ExecuteToolCall(mcpInspector *inspector.MCPInspector, toolName string, toolArgs map[string]any) []byte {
+	output, err := mcpInspector.MethodCall(toolName, toolArgs).Execute()
+	gomega.Expect(output).NotTo(gomega.BeEmpty(),
+		"inspector exited with error but produced no output: %v", err)
+	return output
+}
+
+func ExpectToolError(mcpInspector *inspector.MCPInspector, toolName string, toolArgs map[string]any, wantError string) {
+	output, err := mcpInspector.
+		MethodCall(toolName, toolArgs).
+		Execute()
+
+	if err != nil {
+		gomega.Expect(output).NotTo(gomega.BeEmpty(),
+			"tool error returned exit code but stdout is empty: %v", err)
+	}
+
+	var result mcp.CallToolResult
+	gomega.Expect(result.UnmarshalJSON(output)).To(gomega.Succeed())
+	gomega.Expect(result.IsError).To(gomega.BeTrue())
+	gomega.Expect(result.Content).NotTo(gomega.BeEmpty())
+
+	var messages []string
+	for _, content := range result.Content {
+		textContent, ok := content.(*mcp.TextContent)
+		if ok {
+			messages = append(messages, textContent.Text)
+		}
+	}
+
+	gomega.Expect(messages).NotTo(gomega.BeEmpty(), "expected error text content in CallToolResult")
+	gomega.Expect(strings.Join(messages, "\n")).To(gomega.ContainSubstring(wantError))
+}
+
+// RestrictedSecurityContext returns a SecurityContext that complies with the
+// "restricted" PodSecurity standard (no privilege escalation, drops all caps,
+// runs as non-root user 1000, RuntimeDefault seccomp profile).
+func RestrictedSecurityContext() *corev1.SecurityContext {
+	allowPrivilegeEscalation := false
+	runAsNonRoot := true
+	runAsUser := int64(1000)
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		RunAsNonRoot:             &runAsNonRoot,
+		RunAsUser:                &runAsUser,
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
 }
 
 func GetTestdataPath(relativePath string) string {

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -31,16 +31,6 @@ func UnmarshalCallToolResult[T any](output []byte) T {
 	return resultInTFormat
 }
 
-// ExecuteToolCall runs a tool call and returns the output. It tolerates a non-nil
-// error from Execute() as long as stdout was captured — the MCP inspector CLI exits
-// non-zero when a tool returns isError:true, but stdout still contains the JSON response.
-func ExecuteToolCall(mcpInspector *inspector.MCPInspector, toolName string, toolArgs map[string]any) []byte {
-	output, err := mcpInspector.MethodCall(toolName, toolArgs).Execute()
-	gomega.Expect(output).NotTo(gomega.BeEmpty(),
-		"inspector exited with error but produced no output: %v", err)
-	return output
-}
-
 func ExpectToolError(mcpInspector *inspector.MCPInspector, toolName string, toolArgs map[string]any, wantError string) {
 	output, err := mcpInspector.
 		MethodCall(toolName, toolArgs).


### PR DESCRIPTION
OVN tools (3 new tests):
  - ovn-get,  ovn-lflow-list,  ovn-trace

OVS tools (7 new tests):
  - ovs-list-br,  ovs-list-ports, ovs-list-ifaces, ovs-vsctl-show, ovs-ofctl-dump-flows, ovs-appctl-dump-conntrack, ovs-appctl-ofproto-trace

Network tools tests (tcpdump, pwru)

Changes:
  - Added detailed output display for all tools to aid debugging
  - Followed existing test patterns from kernel_test.go

All tests validate tool functionality and display production-quality network debugging information including logical network topology, OpenFlow rules, and packet traces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for OVN and OVS networking tools, including logical flows, packet tracing, bridges, ports, OpenFlow, conntrack, and databases.
  * Added coverage for Kubernetes ConfigMaps, Pods, Services, Deployments, logs, selectors, and structured JSON/YAML output.
  * Added network capture testing with filtering and packet limits.
  * Improved validation coverage for missing, invalid, or unsafe tool inputs.
  * Added automated discovery and readiness checks for cluster nodes and OVN components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->