### PR TITLE
Add --disable-categories and --disable-tools flags to hide MCP tools being listed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Repo hosting the Model Context Protocol Server for troubleshooting OVN-Kubernete
   - [Dual Mode](#dual-mode)
   - [Local development](#local-development)
   - [Kubernetes deployment](#kubernetes-deployment)
+- [Selectively exposing tools](#selectively-exposing-tools)
 - [Tools available in MCP Server](#tools-available-in-mcp-server)
   - [Live Cluster Mode](#live-cluster-mode-1)
   - [Offline Mode](#offline-mode-1)
@@ -47,6 +48,8 @@ The server currently supports 2 transport modes: `stdio` and `http`.
 | `--tcpdump-image` | `nicolaka/netshoot:v0.15`       | Container image for the **tcpdump** network tool (packet capture). |
 | `--kernel-image` | `nicolaka/netshoot:v0.15`       | Container image for kernel tools (conntrack, ip, iptables, nft). |
 | `--tool-timeout` | `120`                           | Timeout in seconds for tool operations. Set to `0` to disable. |
+| `--disable-categories` | (none)                          | Comma-separated tool categories to hide from clients (valid: `kernel`, `kubernetes`, `must-gather`, `network-tools`, `ovn`, `ovs`, `sosreport`). See [Selectively exposing tools](#selectively-exposing-tools). |
+| `--disable-tools` | (none)                          | Comma-separated tool names to hide from clients (e.g. `tcpdump,pwru`). See [Selectively exposing tools](#selectively-exposing-tools). |
 
 ### Live Cluster Mode
 
@@ -247,6 +250,47 @@ spec:
 ```
 
 From that client pod, call the Service at `http://ovnk-mcp-server.ovn-kubernetes-mcp.svc:8080` (or the fully qualified `*.svc.cluster.local` name). If the client runs in **another** namespace, use a `from` entry with both `namespaceSelector` and `podSelector` as described under [Targeting multiple namespaces by label](https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-multiple-namespaces-by-label). Prefer explicit labels over wide selectors, and keep trusting this path only for workloads you control—there is still no MCP-level authentication on the wire.
+
+---
+
+## Selectively exposing tools
+
+By default the server registers every tool listed in [Tools available in MCP Server](#tools-available-in-mcp-server). Two CLI flags let you hide specific categories or individual tools so clients never see them in `tools/list` and any direct `tools/call` against them is rejected:
+
+| Flag | Example | Effect |
+|------|---------|--------|
+| `--disable-categories` | `--disable-categories=kernel,network-tools` | Hides every tool registered by the listed categories. Categories are the bold headings in the tool table below (`ovn`, `ovs`, `kubernetes`, `kernel`, `network-tools`, `sosreport`, `must-gather`). Unknown category names cause the server to refuse to start. |
+| `--disable-tools` | `--disable-tools=tcpdump,pwru` | Hides individual tools by their registered name (the value in the `Tool` column below). Unknown tool names cause the server to refuse to start, the same as unknown categories. |
+
+The two flags can be combined; the union of their resolved tool names is hidden. The startup log line `Hiding N tool(s) from clients: ...` lists the final set so you can verify the configuration.
+
+Filtering happens at the MCP protocol layer (in middleware), so tools are still registered with the server but never advertised to or callable by clients. Backwards compatible: omitting both flags exposes all tools as before.
+
+**Examples**
+
+Production-leaning: drop packet capture and the wider kernel toolset.
+
+```shell
+ovnk-mcp-server --disable-tools=tcpdump,pwru --disable-categories=kernel
+```
+
+Restrict to OVN/OVS introspection and basic Kubernetes lookups.
+
+```shell
+ovnk-mcp-server --disable-categories=kernel,network-tools,must-gather,sosreport
+```
+
+In a Kubernetes manifest the same options go straight into the container `args`:
+
+```yaml
+args:
+  - --transport=http
+  - --host=0.0.0.0
+  - --port=8080
+  - --mode=live-cluster
+  - --disable-tools=tcpdump,pwru
+  - --disable-categories=kernel
+```
 
 ---
 

--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"flag"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -15,6 +18,7 @@ import (
 	kernelmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/mcp"
 	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/middleware"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/middleware/toolfilter"
 	mustgathermcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/must-gather/mcp"
 	nettoolsmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/network-tools/mcp"
 	ovnmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovn/mcp"
@@ -25,15 +29,16 @@ import (
 const defaultNetshootImage = "nicolaka/netshoot:v0.15"
 
 type MCPServerConfig struct {
-	Mode         string
-	Transport    string
-	Host         string
-	Port         string
-	PwruImage    string
-	TcpdumpImage string
-	Kernel       kernelmcp.Config
-	Kubernetes   kubernetesmcp.Config
-	ToolTimeout  time.Duration
+	Mode          string
+	Transport     string
+	Host          string
+	Port          string
+	PwruImage     string
+	TcpdumpImage  string
+	Kernel        kernelmcp.Config
+	Kubernetes    kubernetesmcp.Config
+	ToolTimeout   time.Duration
+	DisabledTools map[string]bool
 }
 
 // setupLiveCluster sets up the live cluster mode.
@@ -94,6 +99,13 @@ func main() {
 	// Apply timeout middleware to all tool calls if configured.
 	if serverCfg.ToolTimeout > 0 {
 		ovnkMcpServer.AddReceivingMiddleware(middleware.ToolTimeout(serverCfg.ToolTimeout))
+	}
+
+	// Hide tools/categories that the operator opted out of. Filtering happens
+	// at the protocol layer so every category's registration code stays
+	// unchanged; a nil/empty set makes the middleware a no-op.
+	if len(serverCfg.DisabledTools) > 0 {
+		ovnkMcpServer.AddReceivingMiddleware(toolfilter.ToolFilter(serverCfg.DisabledTools))
 	}
 
 	// Setup the MCP server based on the mode.
@@ -164,7 +176,11 @@ func main() {
 
 func parseFlags() *MCPServerConfig {
 	cfg := &MCPServerConfig{}
-	var timeoutSeconds int
+	var (
+		timeoutSeconds     int
+		disabledCategories string
+		disabledTools      string
+	)
 
 	flag.StringVar(&cfg.Mode, "mode", "live-cluster", "Mode of debugging: live-cluster or offline or dual")
 	flag.StringVar(&cfg.Transport, "transport", "stdio", "Transport to use: stdio or http")
@@ -176,6 +192,10 @@ func parseFlags() *MCPServerConfig {
 	flag.StringVar(&cfg.TcpdumpImage, "tcpdump-image", defaultNetshootImage, "Container image for tcpdump operations")
 	flag.StringVar(&cfg.Kernel.Image, "kernel-image", defaultNetshootImage, "Container image for kernel operations")
 	flag.IntVar(&timeoutSeconds, "tool-timeout", 120, "Timeout in seconds for tool operations (0 to disable)")
+	flag.StringVar(&disabledCategories, "disable-categories", "",
+		"Comma-separated tool categories to hide from clients (valid categories: "+strings.Join(toolfilter.Categories(), ",")+")")
+	flag.StringVar(&disabledTools, "disable-tools", "",
+		"Comma-separated tool names to hide from clients (e.g. tcpdump,pwru)")
 	flag.Parse()
 
 	// Convert timeout to duration and apply limits
@@ -189,6 +209,15 @@ func parseFlags() *MCPServerConfig {
 		log.Println("Tool timeout enforcement disabled")
 	} else {
 		log.Printf("Tool timeout: %v", cfg.ToolTimeout)
+	}
+
+	disabled, err := toolfilter.ResolveDisabled(disabledCategories, disabledTools)
+	if err != nil {
+		log.Fatalf("Invalid tool filter configuration: %v", err)
+	}
+	cfg.DisabledTools = disabled
+	if len(disabled) > 0 {
+		log.Printf("Hiding %d tool(s) from clients: %s", len(disabled), strings.Join(slices.Sorted(maps.Keys(disabled)), ","))
 	}
 
 	return cfg

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -39,6 +39,11 @@ spec:
             - --host=0.0.0.0
             - --port=8080
             - --mode=live-cluster
+            # Optional: hide tools or whole categories from MCP clients. Filtering
+            # happens at the protocol layer; omitting these exposes all tools.
+            # See "Selectively exposing tools" in README.md for details.
+            # - --disable-categories=kernel,network-tools
+            # - --disable-tools=tcpdump,pwru
           ports:
             - name: http
               containerPort: 8080

--- a/hack/gen-readme-tools.go
+++ b/hack/gen-readme-tools.go
@@ -12,31 +12,18 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/mcptools"
 )
 
 const (
 	mainPath   = "cmd/ovnk-mcp-server/main.go"
 	readmeName = "README.md"
-	// Sentinel for literal %% in format strings (multi-rune to avoid NUL and collisions with real text).
-	formatVerbSentinel = "\uE000\uE001"
 )
-
-var (
-	reFirstSentence = regexp.MustCompile(`^(.*?\.\s)`)
-	rePeriodAtEnd   = regexp.MustCompile(`^(.*\.)$`)
-	reFormatVerb    = regexp.MustCompile(`%[0-9.*+# \-]*[a-zA-Z]`)
-)
-
-type tool struct {
-	name        string
-	description string
-}
 
 func main() {
-	repoRoot, err := findRepoRoot()
+	repoRoot, err := mcptools.FindRepoRoot()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "find repo root: %v\n", err)
 		os.Exit(1)
@@ -51,15 +38,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	liveTools := make(map[string][]tool)
-	offlineTools := make(map[string][]tool)
+	liveTools := make(map[string][]mcptools.Tool)
+	offlineTools := make(map[string][]mcptools.Tool)
 
 	for _, pkgName := range liveOrder {
 		mcpPath := filepath.Join(pkgDir, pkgName, "mcp", "mcp.go")
 		if _, err := os.Stat(mcpPath); os.IsNotExist(err) {
 			continue
 		}
-		tools, err := extractTools(mcpPath)
+		tools, err := mcptools.ExtractTools(mcpPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", mcpPath, err)
 			continue
@@ -71,7 +58,7 @@ func main() {
 		if _, err := os.Stat(mcpPath); os.IsNotExist(err) {
 			continue
 		}
-		tools, err := extractTools(mcpPath)
+		tools, err := mcptools.ExtractTools(mcpPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", mcpPath, err)
 			continue
@@ -94,7 +81,7 @@ func main() {
 			if i > 0 {
 				prefix = "| |"
 			}
-			fmt.Fprintf(&out, "%s `%s` | %s |\n", prefix, t.name, escapeTableCell(t.description))
+			fmt.Fprintf(&out, "%s `%s` | %s |\n", prefix, t.Name, escapeTableCell(t.Description))
 		}
 	}
 	fmt.Fprintln(&out)
@@ -110,7 +97,7 @@ func main() {
 			if i > 0 {
 				prefix = "| |"
 			}
-			fmt.Fprintf(&out, "%s `%s` | %s |\n", prefix, t.name, escapeTableCell(t.description))
+			fmt.Fprintf(&out, "%s `%s` | %s |\n", prefix, t.Name, escapeTableCell(t.Description))
 		}
 	}
 	generated := out.String()
@@ -119,24 +106,6 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stderr, "Updated %s\n", readmePath)
-}
-
-// findRepoRoot returns the directory that contains go.mod.
-func findRepoRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("go.mod not found")
-		}
-		dir = parent
-	}
 }
 
 // inferModesFromMain parses main.go and returns package names in order of first use in setupLiveCluster and setupOffline.
@@ -150,7 +119,7 @@ func inferModesFromMain(mainPath string) (liveOrder, offlineOrder []string, err 
 	importAliasToPkg := make(map[string]string)
 	trim := "ovn-kubernetes-mcp/pkg/"
 	for _, imp := range node.Imports {
-		path := unquoteString(imp.Path.Value)
+		path := mcptools.UnquoteString(imp.Path.Value)
 		idx := strings.Index(path, trim)
 		if idx == -1 {
 			continue
@@ -221,140 +190,12 @@ func collectPackagesInOrder(block *ast.BlockStmt, aliasToPkg map[string]string) 
 	return order
 }
 
-// firstLine extracts the first line of a description, trimmed and ending at first period if present.
-func firstLine(s string) string {
-	s = strings.TrimSpace(s)
-	// Take first line (up to newline)
-	if idx := strings.Index(s, "\n"); idx != -1 {
-		s = s[:idx]
-	}
-	s = strings.TrimSpace(s)
-	// Take first sentence: stop at ". " or "." at end-of-string
-	if m := reFirstSentence.FindStringSubmatch(s); len(m) > 1 {
-		return strings.TrimSpace(m[1])
-	}
-	// If no ". " found, try period at end of string
-	if m := rePeriodAtEnd.FindStringSubmatch(s); len(m) > 1 {
-		return strings.TrimSpace(m[1])
-	}
-	return s
-}
-
-// extractTools parses the given mcpPath file and returns all MCP tools registered
-// via mcp.AddTool(server, &mcp.Tool{...}). Each tool's description is shortened to
-// the first line or first sentence for the README table. Each tool's short description
-// should be provided in the first line or sentence for this function to work correctly.
-func extractTools(mcpPath string) ([]tool, error) {
-	fset := token.NewFileSet()
-	node, err := parser.ParseFile(fset, mcpPath, nil, parser.ParseComments)
-	if err != nil {
-		return nil, err
-	}
-	var tools []tool
-	ast.Inspect(node, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok || len(call.Args) < 2 {
-			return true
-		}
-		// Check for mcp.AddTool(server, &mcp.Tool{...})
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "AddTool" {
-			return true
-		}
-		ident, ok := sel.X.(*ast.Ident)
-		if !ok || ident.Name != "mcp" {
-			return true
-		}
-		unary, ok := call.Args[1].(*ast.UnaryExpr)
-		if !ok || unary.Op != token.AND {
-			return true
-		}
-		lit, ok := unary.X.(*ast.CompositeLit)
-		if !ok {
-			return true
-		}
-		var name, desc string
-		for _, elt := range lit.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				continue
-			}
-			keyIdent, ok := kv.Key.(*ast.Ident)
-			if !ok {
-				continue
-			}
-			switch keyIdent.Name {
-			case "Name":
-				if bl, ok := kv.Value.(*ast.BasicLit); ok && bl.Kind == token.STRING {
-					name = unquoteString(bl.Value)
-				}
-			case "Description":
-				desc = extractDescription(kv.Value)
-			}
-		}
-		if name != "" {
-			tools = append(tools, tool{name: name, description: firstLine(desc)})
-		}
-		return true
-	})
-	return tools, nil
-}
-
-// extractDescription returns the string value of a Tool's Description field from the AST.
-// It handles dual plain string literals and fmt.Sprintf(format, ...) calls; format verbs
-// in the latter are stripped.
-func extractDescription(expr ast.Expr) string {
-	switch v := expr.(type) {
-	case *ast.BasicLit:
-		if v.Kind == token.STRING {
-			return unquoteString(v.Value)
-		}
-	case *ast.CallExpr:
-		// fmt.Sprintf(`...`, ...) - first argument is format string; replace format verbs so they don't appear literally in README
-		if len(v.Args) >= 1 {
-			if bl, ok := v.Args[0].(*ast.BasicLit); ok && bl.Kind == token.STRING {
-				return stripFormatVerbs(unquoteString(bl.Value))
-			}
-		}
-	}
-	return ""
-}
-
-// stripFormatVerbs replaces Go format verbs (e.g. %d, %s) with placeholders so format strings
-// from fmt.Sprintf read naturally in the README.
-func stripFormatVerbs(s string) string {
-	// Replace %% with a sentinel so we don't touch literal percents (multi-rune to avoid NUL and collisions)
-	s = strings.ReplaceAll(s, "%%", formatVerbSentinel)
-	s = reFormatVerb.ReplaceAllString(s, "N")
-	s = strings.ReplaceAll(s, formatVerbSentinel, "%")
-	return s
-}
-
 // escapeTableCell escapes content for use in a markdown table cell so that | and newlines don't
 // break the table.
 func escapeTableCell(s string) string {
 	s = strings.ReplaceAll(s, "|", "&#124;")
 	s = strings.ReplaceAll(s, "\n", " ")
 	return strings.TrimSpace(s)
-}
-
-// unquoteString removes surrounding backticks or double quotes from a Go string literal.
-// It uses strconv.Unquote to handle escape sequences. Returns the unquoted string or the
-// original string if unquoting fails.
-func unquoteString(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
-		return s[1 : len(s)-1]
-	}
-	if len(s) >= 2 && (s[0] == '"' && s[len(s)-1] == '"') {
-		// Try to unquote using strconv.Unquote for escape sequences. If it fails,
-		// use simple unquote.
-		if u, err := strconv.Unquote(s); err == nil {
-			return u
-		}
-		return s[1 : len(s)-1]
-	}
-	return s
 }
 
 // readREADME reads and returns the full contents of the file at path.

--- a/pkg/middleware/toolfilter/catalog_sync_test.go
+++ b/pkg/middleware/toolfilter/catalog_sync_test.go
@@ -1,0 +1,37 @@
+package toolfilter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/mcptools"
+)
+
+// TestToolsByCategorySync verifies that the toolsByCategory map matches the
+// tools actually registered via mcp.AddTool calls under pkg/*/mcp/mcp.go.
+// If a contributor adds, removes, or renames a tool without updating the
+// map, this test fails with a diff naming the exact category and tool change.
+func TestToolsByCategorySync(t *testing.T) {
+	repoRoot, err := mcptools.FindRepoRoot()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+	catalog, err := mcptools.Catalog(repoRoot)
+	if err != nil {
+		t.Fatalf("scan pkg/*/mcp/mcp.go: %v", err)
+	}
+
+	fromCode := make(map[string][]string, len(catalog))
+	for cat, tools := range catalog {
+		names := make([]string, 0, len(tools))
+		for _, tool := range tools {
+			names = append(names, tool.Name)
+		}
+		fromCode[cat] = names
+	}
+
+	if diff := cmp.Diff(toolsByCategory, fromCode); diff != "" {
+		t.Errorf("toolsByCategory must match pkg/*/mcp/mcp.go (-map, +code):\n%s", diff)
+	}
+}

--- a/pkg/middleware/toolfilter/toolfilter.go
+++ b/pkg/middleware/toolfilter/toolfilter.go
@@ -1,0 +1,151 @@
+package toolfilter
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// toolsByCategory enumerates the tools registered by each pkg/<category>/mcp
+// package. It is the source of truth for resolving disabled categories into
+// individual tool names, and for typo-detecting tool names supplied by the
+// operator. Keep this in sync with the AddTools implementations under
+// pkg/*/mcp/mcp.go; the README "Tools available in MCP Server" table is the
+// canonical reference.
+var toolsByCategory = map[string][]string{
+	"kubernetes":    {"pod-logs", "resource-get", "resource-list"},
+	"ovn":           {"ovn-show", "ovn-get", "ovn-lflow-list", "ovn-trace"},
+	"ovs":           {"ovs-list-br", "ovs-list-ports", "ovs-list-ifaces", "ovs-vsctl-show", "ovs-ofctl-dump-flows", "ovs-appctl-dump-conntrack", "ovs-appctl-ofproto-trace"},
+	"kernel":        {"get-conntrack", "get-iptables", "get-nft", "get-ip"},
+	"network-tools": {"tcpdump", "pwru"},
+	"sosreport":     {"sos-list-plugins", "sos-list-commands", "sos-search-commands", "sos-get-command", "sos-search-pod-logs"},
+	"must-gather":   {"must-gather-get-resource", "must-gather-list-resources", "must-gather-pod-logs", "must-gather-ovnk-info", "must-gather-list-northbound-databases", "must-gather-list-southbound-databases", "must-gather-query-database"},
+}
+
+// Categories returns a sorted list of known tool category names. Intended for
+// building CLI help strings and error messages.
+func Categories() []string {
+	return slices.Sorted(maps.Keys(toolsByCategory))
+}
+
+// ResolveDisabled expands comma-separated category and tool name lists into a
+// single set of tool names to hide. Whitespace in either list is trimmed and
+// empty entries are ignored. Unknown category or tool names return an error so
+// configuration bugs (typos, stale configs) fail fast at startup rather than
+// silently disabling nothing.
+func ResolveDisabled(disabledCategories, disabledTools string) (map[string]bool, error) {
+	disabled := map[string]bool{}
+
+	for _, cat := range splitCSV(disabledCategories) {
+		tools, ok := toolsByCategory[cat]
+		if !ok {
+			return nil, fmt.Errorf("unknown category %q (valid: %s)", cat, strings.Join(Categories(), ", "))
+		}
+		for _, t := range tools {
+			disabled[t] = true
+		}
+	}
+
+	known := allKnownTools()
+	for _, t := range splitCSV(disabledTools) {
+		if !known[t] {
+			return nil, fmt.Errorf("unknown tool %q", t)
+		}
+		disabled[t] = true
+	}
+
+	return disabled, nil
+}
+
+// ToolFilter returns an MCP receiving middleware that hides tools whose names
+// appear in disabledTools from tools/list responses and rejects tools/call
+// requests targeting those names with a "disabled by server configuration"
+// error. A nil or empty disabledTools map makes the middleware a no-op, so it
+// is safe to install unconditionally.
+//
+// Filtering at the middleware layer keeps every pkg/<category>/mcp registration
+// site untouched: tools are still registered with the SDK, the server's
+// listTools handler still returns them, and this wrapper strips them out on the
+// way back to the client.
+func ToolFilter(disabledTools map[string]bool) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if len(disabledTools) == 0 {
+				return next(ctx, method, req)
+			}
+
+			switch method {
+			case "tools/call":
+				if name := callToolName(req); name != "" && disabledTools[name] {
+					return nil, fmt.Errorf("tool %q is disabled by server configuration", name)
+				}
+				return next(ctx, method, req)
+
+			case "tools/list":
+				res, err := next(ctx, method, req)
+				if err != nil {
+					return res, err
+				}
+				if lr, ok := res.(*mcp.ListToolsResult); ok && len(lr.Tools) > 0 {
+					filtered := make([]*mcp.Tool, 0, len(lr.Tools))
+					for _, t := range lr.Tools {
+						if t == nil || disabledTools[t.Name] {
+							continue
+						}
+						filtered = append(filtered, t)
+					}
+					lr.Tools = filtered
+				}
+				return res, err
+
+			default:
+				return next(ctx, method, req)
+			}
+		}
+	}
+}
+
+// splitCSV splits a comma-separated string, trims whitespace from each entry,
+// and drops empties so " a, ,b " becomes []string{"a","b"}.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// allKnownTools returns the union of every tool name in toolsByCategory as a
+// set, used for typo detection on disabled tool names.
+func allKnownTools() map[string]bool {
+	out := map[string]bool{}
+	for _, tools := range toolsByCategory {
+		for _, t := range tools {
+			out[t] = true
+		}
+	}
+	return out
+}
+
+// callToolName extracts the tool name from a tools/call request. Returns "" if
+// the request shape is unexpected.
+func callToolName(req mcp.Request) string {
+	if req == nil {
+		return ""
+	}
+	p, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+	if !ok || p == nil {
+		return ""
+	}
+	return p.Name
+}

--- a/pkg/middleware/toolfilter/toolfilter_test.go
+++ b/pkg/middleware/toolfilter/toolfilter_test.go
@@ -1,0 +1,261 @@
+package toolfilter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestToolFilter(t *testing.T) {
+	t.Run("nil disabled set is a no-op for tools/list", func(t *testing.T) {
+		listResult := &mcp.ListToolsResult{
+			Tools: []*mcp.Tool{{Name: "tcpdump"}, {Name: "ovn-show"}},
+		}
+		m := ToolFilter(nil)
+		h := m(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			return listResult, nil
+		})
+
+		res, err := h(context.Background(), "tools/list", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		lr := res.(*mcp.ListToolsResult)
+		if len(lr.Tools) != 2 {
+			t.Fatalf("expected 2 tools to pass through, got %d", len(lr.Tools))
+		}
+	})
+
+	t.Run("empty disabled set is a no-op for tools/call", func(t *testing.T) {
+		m := ToolFilter(map[string]bool{})
+		called := false
+		h := m(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			called = true
+			return nil, nil
+		})
+
+		_, err := h(context.Background(), "tools/call", newCallReq("tcpdump"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected next handler to be called")
+		}
+	})
+
+	t.Run("tools/list filters out disabled tools", func(t *testing.T) {
+		listResult := &mcp.ListToolsResult{
+			Tools: []*mcp.Tool{
+				{Name: "tcpdump"},
+				{Name: "ovn-show"},
+				{Name: "pwru"},
+				{Name: "ovs-list-br"},
+			},
+		}
+		// Snapshot the original Tools slice header before invoking the
+		// middleware. ToolFilter must allocate a fresh backing array for the
+		// filtered output rather than reusing this one in place
+		// (lr.Tools[:0] would silently mutate any caller still holding a
+		// reference). Comparing this snapshot after the call catches that
+		// regression.
+		originalTools := listResult.Tools
+		originalNames := []string{"tcpdump", "ovn-show", "pwru", "ovs-list-br"}
+
+		m := ToolFilter(map[string]bool{"tcpdump": true, "pwru": true})
+		h := m(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			return listResult, nil
+		})
+
+		res, err := h(context.Background(), "tools/list", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		lr := res.(*mcp.ListToolsResult)
+		if len(lr.Tools) != 2 {
+			t.Fatalf("expected 2 tools after filtering, got %d", len(lr.Tools))
+		}
+		for _, tool := range lr.Tools {
+			if tool.Name == "tcpdump" || tool.Name == "pwru" {
+				t.Fatalf("disabled tool %q was not filtered out", tool.Name)
+			}
+		}
+
+		// The caller's view of the original slice must be unchanged - same
+		// length, same entries in the same order. If ToolFilter ever reverts
+		// to filtering in place via lr.Tools[:0], the disabled entries here
+		// would be overwritten by the kept ones and this assertion fires.
+		if len(originalTools) != len(originalNames) {
+			t.Fatalf("caller's Tools slice length changed: got %d, want %d", len(originalTools), len(originalNames))
+		}
+		for i, want := range originalNames {
+			if originalTools[i] == nil {
+				t.Fatalf("caller's Tools[%d] was nilled out by ToolFilter", i)
+			}
+			if got := originalTools[i].Name; got != want {
+				t.Fatalf("caller's Tools[%d].Name = %q, want %q (ToolFilter mutated the caller's backing array)", i, got, want)
+			}
+		}
+	})
+
+	t.Run("tools/list propagates errors from next without filtering", func(t *testing.T) {
+		m := ToolFilter(map[string]bool{"tcpdump": true})
+		sentinel := contextDeadline()
+		h := m(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			return nil, sentinel
+		})
+
+		_, err := h(context.Background(), "tools/list", nil)
+		if err != sentinel {
+			t.Fatalf("expected sentinel error, got: %v", err)
+		}
+	})
+
+	t.Run("tools/call rejects disabled tool with descriptive error", func(t *testing.T) {
+		m := ToolFilter(map[string]bool{"tcpdump": true})
+		called := false
+		h := m(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			called = true
+			return nil, nil
+		})
+
+		_, err := h(context.Background(), "tools/call", newCallReq("tcpdump"))
+		if err == nil {
+			t.Fatal("expected error rejecting disabled tool, got nil")
+		}
+		if called {
+			t.Fatal("next handler must not be invoked for disabled tool")
+		}
+		if !strings.Contains(err.Error(), "tcpdump") || !strings.Contains(err.Error(), "disabled") {
+			t.Fatalf("error message should mention tool name and disabled state, got: %v", err)
+		}
+	})
+
+	t.Run("tools/call allows enabled tool through", func(t *testing.T) {
+		m := ToolFilter(map[string]bool{"tcpdump": true})
+		called := false
+		h := m(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			called = true
+			return nil, nil
+		})
+
+		_, err := h(context.Background(), "tools/call", newCallReq("ovn-show"))
+		if err != nil {
+			t.Fatalf("unexpected error for enabled tool: %v", err)
+		}
+		if !called {
+			t.Fatal("expected next handler to be called for enabled tool")
+		}
+	})
+
+	t.Run("other methods are passed through unmodified", func(t *testing.T) {
+		m := ToolFilter(map[string]bool{"tcpdump": true})
+		called := false
+		h := m(func(_ context.Context, method string, _ mcp.Request) (mcp.Result, error) {
+			called = true
+			if method != "initialize" {
+				t.Fatalf("expected method 'initialize', got %q", method)
+			}
+			return nil, nil
+		})
+
+		if _, err := h(context.Background(), "initialize", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected next handler to be called for non-tool method")
+		}
+	})
+}
+
+// newCallReq builds a minimal CallToolRequest with the given tool name.
+func newCallReq(name string) *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Name: name},
+	}
+}
+
+// contextDeadline is a sentinel error value distinct from anything the
+// middleware itself produces. Used to verify error pass-through.
+func contextDeadline() error { return context.DeadlineExceeded }
+
+func TestCategories(t *testing.T) {
+	cats := Categories()
+	if len(cats) == 0 {
+		t.Fatal("expected at least one known category")
+	}
+	for i := 1; i < len(cats); i++ {
+		if cats[i-1] >= cats[i] {
+			t.Fatalf("categories must be sorted, got %v", cats)
+		}
+	}
+}
+
+func TestResolveDisabled(t *testing.T) {
+	t.Run("empty inputs return empty set", func(t *testing.T) {
+		disabled, err := ResolveDisabled("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(disabled) != 0 {
+			t.Fatalf("expected empty set, got %v", disabled)
+		}
+	})
+
+	t.Run("expands a category into its tool names", func(t *testing.T) {
+		disabled, err := ResolveDisabled("network-tools", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !disabled["tcpdump"] || !disabled["pwru"] {
+			t.Fatalf("expected network-tools to expand to tcpdump and pwru, got %v", disabled)
+		}
+	})
+
+	t.Run("merges categories and individual tool names without duplicates", func(t *testing.T) {
+		disabled, err := ResolveDisabled("network-tools", "tcpdump,ovn-show")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{"tcpdump": true, "pwru": true, "ovn-show": true}
+		if len(disabled) != len(want) {
+			t.Fatalf("expected %d entries, got %d (%v)", len(want), len(disabled), disabled)
+		}
+		for name := range want {
+			if !disabled[name] {
+				t.Fatalf("expected %q to be disabled, got %v", name, disabled)
+			}
+		}
+	})
+
+	t.Run("trims whitespace and ignores empty entries", func(t *testing.T) {
+		disabled, err := ResolveDisabled(" network-tools , ", " tcpdump , ,pwru ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !disabled["tcpdump"] || !disabled["pwru"] {
+			t.Fatalf("expected tcpdump and pwru regardless of whitespace, got %v", disabled)
+		}
+	})
+
+	t.Run("unknown category is a hard error", func(t *testing.T) {
+		_, err := ResolveDisabled("does-not-exist", "")
+		if err == nil {
+			t.Fatal("expected error for unknown category, got nil")
+		}
+		if !strings.Contains(err.Error(), "does-not-exist") {
+			t.Fatalf("error should mention the bad category, got: %v", err)
+		}
+	})
+
+	t.Run("unknown tool name is a hard error", func(t *testing.T) {
+		_, err := ResolveDisabled("", "tcpdumb")
+		if err == nil {
+			t.Fatal("expected error for unknown tool, got nil")
+		}
+		if !strings.Contains(err.Error(), "tcpdumb") {
+			t.Fatalf("error should mention the bad tool name, got: %v", err)
+		}
+	})
+}

--- a/pkg/utils/mcptools/catalog.go
+++ b/pkg/utils/mcptools/catalog.go
@@ -1,0 +1,271 @@
+// Package mcptools holds helpers that parse the MCP tool registrations under
+// pkg/*/mcp/mcp.go. The same primitives are consumed by two places that must
+// agree about which tools exist:
+//
+//   - hack/gen-readme-tools.go renders the "Tools available in MCP Server"
+//     table in README.md from these registrations.
+//   - pkg/middleware/toolfilter/catalog_sync_test.go asserts the
+//     toolsByCategory map in pkg/middleware/toolfilter/toolfilter.go matches
+//     the live registrations, so the --disable-categories / --disable-tools
+//     flags cannot silently drift away from what the server actually exposes.
+//
+// Keeping the AST scanner in one place eliminates the risk of those two
+// callers disagreeing about how a tool declaration is recognised.
+package mcptools
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// formatVerbSentinel is used while transforming format strings so a literal
+	// "%%" survives a pass through format-verb stripping. Multi-rune so it cannot
+	// collide with anything that occurs in real descriptions.
+	formatVerbSentinel = "\uE000\uE001"
+
+	// sdkImportPath is the canonical Go import path of the MCP SDK. Files that
+	// do not import this path are assumed not to register any MCP tools.
+	sdkImportPath = "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var (
+	reFirstSentence = regexp.MustCompile(`^(.*?\.\s)`)
+	rePeriodAtEnd   = regexp.MustCompile(`^(.*\.)$`)
+	reFormatVerb    = regexp.MustCompile(`%[0-9.*+# \-]*[a-zA-Z]`)
+)
+
+// Tool represents a single MCP tool extracted from an mcp.AddTool registration
+// in a pkg/<category>/mcp/mcp.go file. Description is shortened to the first
+// line / first sentence so it renders inline in a Markdown table.
+type Tool struct {
+	Name        string
+	Description string
+}
+
+// FindRepoRoot returns the directory that contains go.mod, walking up from the
+// current working directory. Both the README generator and the sync test rely
+// on this so they keep working regardless of which subdirectory they were
+// invoked from.
+func FindRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+// ExtractTools parses the given mcp.go file and returns every MCP tool
+// registered via <alias>.AddTool(server, &<alias>.Tool{...}, ...). The local
+// alias of the MCP SDK is detected from the file's imports, so a file that
+// uses, say, `import sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"` is
+// still scanned correctly. Tools are returned in source order so callers that
+// care about registration order (the README generator, the sync test) get a
+// stable, meaningful sequence.
+func ExtractTools(mcpPath string) ([]Tool, error) {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, mcpPath, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	mcpAlias, dotImported, ok := findMCPImportAlias(node)
+	if !ok {
+		// File doesn't import the MCP SDK (or imports it as `_`). No tool
+		// registrations are possible.
+		return nil, nil
+	}
+	var tools []Tool
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) < 2 {
+			return true
+		}
+		if !isMCPAddToolCall(call.Fun, mcpAlias, dotImported) {
+			return true
+		}
+		unary, ok := call.Args[1].(*ast.UnaryExpr)
+		if !ok || unary.Op != token.AND {
+			return true
+		}
+		lit, ok := unary.X.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		var name, desc string
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			keyIdent, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			switch keyIdent.Name {
+			case "Name":
+				if bl, ok := kv.Value.(*ast.BasicLit); ok && bl.Kind == token.STRING {
+					name = UnquoteString(bl.Value)
+				}
+			case "Description":
+				desc = extractDescription(kv.Value)
+			}
+		}
+		if name != "" {
+			tools = append(tools, Tool{Name: name, Description: firstLine(desc)})
+		}
+		return true
+	})
+	return tools, nil
+}
+
+// findMCPImportAlias scans file.Imports for the MCP SDK and returns the local
+// alias used to qualify references to it. The bool result is false when the
+// file doesn't import the SDK at all (or imports it blank, with "_"), in which
+// case the caller should skip the file. When the SDK is dot-imported, alias is
+// empty and dotImported is true so the caller can recognise bare identifiers.
+func findMCPImportAlias(file *ast.File) (alias string, dotImported, ok bool) {
+	for _, imp := range file.Imports {
+		if imp.Path == nil || UnquoteString(imp.Path.Value) != sdkImportPath {
+			continue
+		}
+		if imp.Name == nil {
+			// Unaliased: local name is the import path's last segment, which
+			// is "mcp" for this SDK.
+			return "mcp", false, true
+		}
+		switch imp.Name.Name {
+		case ".":
+			return "", true, true
+		case "_":
+			return "", false, false
+		default:
+			return imp.Name.Name, false, true
+		}
+	}
+	return "", false, false
+}
+
+// isMCPAddToolCall reports whether fun refers to the SDK's AddTool function,
+// taking into account the local alias the file uses (or dot-imports).
+func isMCPAddToolCall(fun ast.Expr, mcpAlias string, dotImported bool) bool {
+	if dotImported {
+		ident, ok := fun.(*ast.Ident)
+		return ok && ident.Name == "AddTool"
+	}
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "AddTool" {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == mcpAlias
+}
+
+// Catalog walks every pkg/*/mcp/mcp.go file under repoRoot and returns a map
+// of category name (the pkg/<name> directory) to the tools registered there
+// in source order. Subdirectories that contain no mcp/mcp.go file, and files
+// that register zero tools, are silently skipped.
+func Catalog(repoRoot string) (map[string][]Tool, error) {
+	pkgDir := filepath.Join(repoRoot, "pkg")
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", pkgDir, err)
+	}
+	out := make(map[string][]Tool)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		mcpPath := filepath.Join(pkgDir, e.Name(), "mcp", "mcp.go")
+		if _, err := os.Stat(mcpPath); os.IsNotExist(err) {
+			continue
+		}
+		tools, err := ExtractTools(mcpPath)
+		if err != nil {
+			return nil, fmt.Errorf("extract %s: %w", mcpPath, err)
+		}
+		if len(tools) == 0 {
+			continue
+		}
+		out[e.Name()] = tools
+	}
+	return out, nil
+}
+
+// UnquoteString removes surrounding backticks or double quotes from a Go
+// string literal. It uses strconv.Unquote to handle escape sequences inside
+// double-quoted strings and falls back to a literal strip if that fails.
+func UnquoteString(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	if len(s) >= 2 && (s[0] == '"' && s[len(s)-1] == '"') {
+		if u, err := strconv.Unquote(s); err == nil {
+			return u
+		}
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// extractDescription returns the string value of a Tool's Description field
+// from the AST. It handles both plain string literals and
+// fmt.Sprintf(format, ...) calls; format verbs in the latter are stripped so
+// they don't appear literally in the README.
+func extractDescription(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		if v.Kind == token.STRING {
+			return UnquoteString(v.Value)
+		}
+	case *ast.CallExpr:
+		if len(v.Args) >= 1 {
+			if bl, ok := v.Args[0].(*ast.BasicLit); ok && bl.Kind == token.STRING {
+				return stripFormatVerbs(UnquoteString(bl.Value))
+			}
+		}
+	}
+	return ""
+}
+
+// stripFormatVerbs replaces Go format verbs (e.g. %d, %s) with placeholders so
+// format strings extracted from fmt.Sprintf read naturally in the README.
+func stripFormatVerbs(s string) string {
+	s = strings.ReplaceAll(s, "%%", formatVerbSentinel)
+	s = reFormatVerb.ReplaceAllString(s, "N")
+	s = strings.ReplaceAll(s, formatVerbSentinel, "%")
+	return s
+}
+
+// firstLine extracts the first line of a description, trimmed and ending at
+// the first period if present.
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if idx := strings.Index(s, "\n"); idx != -1 {
+		s = s[:idx]
+	}
+	s = strings.TrimSpace(s)
+	if m := reFirstSentence.FindStringSubmatch(s); len(m) > 1 {
+		return strings.TrimSpace(m[1])
+	}
+	if m := rePeriodAtEnd.FindStringSubmatch(s); len(m) > 1 {
+		return strings.TrimSpace(m[1])
+	}
+	return s
+}


### PR DESCRIPTION
A new ToolFilter middleware strips disabled tools from tools/list and rejects tools/call for them, so operators can shrink the exposed surface without touching any category package.

Motivation
By default the server exposes every registered tool. which causes two problems

**Overlap with other MCP servers.** Agents often pair this server with a generic kubernetes-MCP, which already provides well-tested implementations of pod-logs, resource-get, and resource-list. Exposing duplicates here bloats the agent's context window and creates tool-selection ambiguity.
**Environment-dependent capabilities.** Some tools only work where the underlying primitives exist — pwru requires eBPF, and tcpdump plus the kernel-debug tools rely on privileged debug pods that many clusters forbid via PSA/OPA. Advertising a tool that will reliably fail in a given environment is worse than hiding it.
--disable-categories and --disable-tools let operators trim the exposed surface to match both the environment and the rest of their MCP fleet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--disable-categories` and `--disable-tools` CLI flags to selectively hide tools from MCP clients. Hidden tools do not appear in tool lists and reject call requests, while remaining registered server-side.
  * Tool filtering is applied at the MCP protocol layer.
  * Server startup fails if invalid category or tool names are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes issue #12 