### PR TITLE
Move timeout middleware into its own package

### DIFF
--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -17,7 +17,7 @@ import (
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	kernelmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/mcp"
 	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
-	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/middleware"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/middleware/timeout"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/middleware/toolfilter"
 	mustgathermcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/must-gather/mcp"
 	nettoolsmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/network-tools/mcp"
@@ -98,7 +98,7 @@ func main() {
 
 	// Apply timeout middleware to all tool calls if configured.
 	if serverCfg.ToolTimeout > 0 {
-		ovnkMcpServer.AddReceivingMiddleware(middleware.ToolTimeout(serverCfg.ToolTimeout))
+		ovnkMcpServer.AddReceivingMiddleware(timeout.ToolTimeout(serverCfg.ToolTimeout))
 	}
 
 	// Hide tools/categories that the operator opted out of. Filtering happens

--- a/pkg/middleware/timeout/timeout.go
+++ b/pkg/middleware/timeout/timeout.go
@@ -1,4 +1,4 @@
-package middleware
+package timeout
 
 import (
 	"context"

--- a/pkg/middleware/timeout/timeout_test.go
+++ b/pkg/middleware/timeout/timeout_test.go
@@ -1,4 +1,4 @@
-package middleware
+package timeout
 
 import (
 	"context"


### PR DESCRIPTION
Relocate the ToolTimeout middleware from pkg/middleware to a dedicated pkg/middleware/timeout package, mirroring the toolfilter package. This keeps each middleware self-contained so future additions don't crowd a single package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal timeout middleware package structure for improved code maintainability and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->