### PR TITLE
Refactor node debug tool

### DIFF
--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -33,8 +33,7 @@ type MCPServerConfig struct {
 	Transport     string
 	Host          string
 	Port          string
-	PwruImage     string
-	TcpdumpImage  string
+	NetworkTools  nettoolsmcp.Config
 	Kernel        kernelmcp.Config
 	Kubernetes    kubernetesmcp.Config
 	ToolTimeout   time.Duration
@@ -64,11 +63,17 @@ func setupLiveCluster(serverCfg *MCPServerConfig, server *mcp.Server) {
 	log.Println("Adding OVS tools to OVN-K MCP server")
 	ovsServer.AddTools(server)
 
-	kernelMcpServer := kernelmcp.NewMCPServer(k8sMcpServer, serverCfg.Kernel)
+	kernelMcpServer, err := kernelmcp.NewMCPServer(k8sMcpServer.RunDebugNode, serverCfg.Kernel)
+	if err != nil {
+		log.Fatalf("Failed to create Kernel MCP server: %v", err)
+	}
 	log.Println("Adding Kernel tools to OVN-K MCP server")
 	kernelMcpServer.AddTools(server)
 
-	netToolsServer := nettoolsmcp.NewMCPServer(k8sMcpServer, serverCfg.PwruImage, serverCfg.TcpdumpImage)
+	netToolsServer, err := nettoolsmcp.NewMCPServer(k8sMcpServer.RunDebugNode, k8sMcpServer.RunPodExecCommand, serverCfg.NetworkTools)
+	if err != nil {
+		log.Fatalf("Failed to create Network Tools MCP server: %v", err)
+	}
 	log.Println("Adding network tools to OVN-K MCP server")
 	netToolsServer.AddTools(server)
 }
@@ -187,9 +192,9 @@ func parseFlags() *MCPServerConfig {
 	flag.StringVar(&cfg.Host, "host", "localhost", "Host to bind to (use 0.0.0.0 for container/cluster)")
 	flag.StringVar(&cfg.Port, "port", "8080", "Port to use")
 	flag.StringVar(&cfg.Kubernetes.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
-	flag.StringVar(&cfg.PwruImage, "pwru-image", "docker.io/cilium/pwru:v1.0.10", "Container image for pwru operations")
+	flag.StringVar(&cfg.NetworkTools.PwruImage, "pwru-image", "docker.io/cilium/pwru:v1.0.10", "Container image for pwru operations")
 
-	flag.StringVar(&cfg.TcpdumpImage, "tcpdump-image", defaultNetshootImage, "Container image for tcpdump operations")
+	flag.StringVar(&cfg.NetworkTools.TcpdumpImage, "tcpdump-image", defaultNetshootImage, "Container image for tcpdump operations")
 	flag.StringVar(&cfg.Kernel.Image, "kernel-image", defaultNetshootImage, "Container image for kernel operations")
 	flag.IntVar(&timeoutSeconds, "tool-timeout", 120, "Timeout in seconds for tool operations (0 to disable)")
 	flag.StringVar(&disabledCategories, "disable-categories", "",

--- a/pkg/kernel/mcp/conntrack.go
+++ b/pkg/kernel/mcp/conntrack.go
@@ -19,8 +19,15 @@ const conntrackSystemFile = "/proc/net/nf_conntrack"
 // TODO: Add support for conntrack event monitoring (-E flag).
 // TODO: Add support for -G (get specific entry) command.
 func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, in types.ListConntrackParams) (*mcp.CallToolResult, types.Result, error) {
+	// If timeout is specified, create a new context with timeout
+	var cancel context.CancelFunc
+	ctx, cancel = in.TimeoutParams.WithTimeout(ctx)
+	if cancel != nil {
+		defer cancel()
+	}
+
 	// Falls back to /proc/net/nf_conntrack parsing when conntrack CLI unavailable.
-	err := s.utilityExists(ctx, req, in.Node, "conntrack")
+	err := s.utilityExists(ctx, in.Namespace, in.Node, "conntrack")
 	conntrackCliAvailable := err == nil // true if conntrack CLI is available, false otherwise
 	if err := validateConntrackCommand(in.Command, conntrackCliAvailable); err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
@@ -31,9 +38,9 @@ func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, 
 
 	var stdout string
 	if !conntrackCliAvailable {
-		stdout, err = s.getConntrackFromFile(ctx, req, in.Node)
+		stdout, err = s.getConntrackFromFile(ctx, in.Namespace, in.Node)
 	} else {
-		stdout, err = s.getConntrackUsingCLI(ctx, req, in.Node, strings.TrimSpace(in.Command), in.FilterParameters)
+		stdout, err = s.getConntrackUsingCLI(ctx, in.Namespace, in.Node, strings.TrimSpace(in.Command), in.FilterParameters)
 	}
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
@@ -49,7 +56,7 @@ func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 // getConntrackUsingCLI executes conntrack CLI commands.
-func (s *MCPServer) getConntrackUsingCLI(ctx context.Context, req *mcp.CallToolRequest, node, command, filterParameters string) (string, error) {
+func (s *MCPServer) getConntrackUsingCLI(ctx context.Context, namespace, node, command, filterParameters string) (string, error) {
 	cmd := commandbuilder.NewCommand("conntrack")
 	switch command {
 	case "-L", "--dump":
@@ -63,15 +70,15 @@ func (s *MCPServer) getConntrackUsingCLI(ctx context.Context, req *mcp.CallToolR
 		cmd.Add("-L")
 		cmd.Add(strings.Fields(filterParameters)...)
 	}
-	return s.executeCommand(ctx, req, node, cmd.Build())
+	return s.executeCommand(ctx, namespace, node, cmd.Build())
 }
 
 // getConntrackFromFile parses /proc/net/nf_conntrack directly.
 // TODO: Add filter support while getting conntrack entries from /proc/net/nf_conntrack.
-func (s *MCPServer) getConntrackFromFile(ctx context.Context, req *mcp.CallToolRequest, node string) (string, error) {
+func (s *MCPServer) getConntrackFromFile(ctx context.Context, namespace, node string) (string, error) {
 	cmd := commandbuilder.NewCommand("cat")
 	cmd.Add(conntrackSystemFile)
-	return s.executeCommand(ctx, req, node, cmd.Build())
+	return s.executeCommand(ctx, namespace, node, cmd.Build())
 }
 
 // validateConntrackCommand validates the command to be used to get list of conntrack entries.

--- a/pkg/kernel/mcp/ip.go
+++ b/pkg/kernel/mcp/ip.go
@@ -16,7 +16,14 @@ import (
 // GetIPCommandOutput executes 'ip' utility commands on a node.
 // Requires ip utility in the debug container image.
 func (s *MCPServer) GetIPCommandOutput(ctx context.Context, req *mcp.CallToolRequest, in types.ListIPParams) (*mcp.CallToolResult, types.Result, error) {
-	err := s.utilityExists(ctx, req, in.Node, "ip")
+	// If timeout is specified, create a new context with timeout
+	var cancel context.CancelFunc
+	ctx, cancel = in.TimeoutParams.WithTimeout(ctx)
+	if cancel != nil {
+		defer cancel()
+	}
+
+	err := s.utilityExists(ctx, in.Namespace, in.Node, "ip")
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting ip data: failed to verify ip utility availability in configured image: %w", err)
 	}
@@ -36,7 +43,7 @@ func (s *MCPServer) GetIPCommandOutput(ctx context.Context, req *mcp.CallToolReq
 	cmd.Add(strings.Fields(in.Command)...)
 	cmd.AddIfNotEmpty(in.FilterParameters, strings.Fields(in.FilterParameters)...)
 
-	stdout, err := s.executeCommand(ctx, req, in.Node, cmd.Build())
+	stdout, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting ip data: %w", err)
 	}

--- a/pkg/kernel/mcp/iptables.go
+++ b/pkg/kernel/mcp/iptables.go
@@ -16,7 +16,14 @@ import (
 // GetIptables retrieves iptables/ip6tables rules from a Kubernetes node.
 // Automatically detects IPv6 and uses ip6tables when needed.
 func (s *MCPServer) GetIptables(ctx context.Context, req *mcp.CallToolRequest, in types.ListIPTablesParams) (*mcp.CallToolResult, types.Result, error) {
-	err := s.utilityExists(ctx, req, in.Node, "iptables")
+	// If timeout is specified, create a new context with timeout
+	var cancel context.CancelFunc
+	ctx, cancel = in.TimeoutParams.WithTimeout(ctx)
+	if cancel != nil {
+		defer cancel()
+	}
+
+	err := s.utilityExists(ctx, in.Namespace, in.Node, "iptables")
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: failed to verify iptables utility availability in configured image: %w", err)
 	}
@@ -44,7 +51,7 @@ func (s *MCPServer) GetIptables(ctx context.Context, req *mcp.CallToolRequest, i
 	// FilterParameters are invalid with -S/--list-rules command
 	cmd.AddIf(in.FilterParameters != "" && command != "-S" && command != "--list-rules", strings.Fields(in.FilterParameters)...)
 
-	stdout, err := s.executeCommand(ctx, req, in.Node, cmd.Build())
+	stdout, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: %w", err)
 	}

--- a/pkg/kernel/mcp/mcp.go
+++ b/pkg/kernel/mcp/mcp.go
@@ -3,11 +3,13 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
-	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/timeout"
 )
+
+type RunDebugNodeCommandFuncType func(ctx context.Context, namespace string, nodeName string, image string, command []string, hostPath string, mountPath string, timeout time.Duration) (string, string, error)
 
 // Config contains the configuration for the kernel MCP server.
 type Config struct {
@@ -17,16 +19,19 @@ type Config struct {
 
 // MCPServer provides MCP server functionality for kernel operations.
 type MCPServer struct {
-	k8sMcpServer *kubernetesmcp.MCPServer
-	cfg          Config
+	runDebugNodeCommand RunDebugNodeCommandFuncType
+	cfg                 Config
 }
 
 // NewMCPServer creates a new MCP server instance
-func NewMCPServer(k8sMcpServer *kubernetesmcp.MCPServer, cfg Config) *MCPServer {
-	return &MCPServer{
-		k8sMcpServer: k8sMcpServer,
-		cfg:          cfg,
+func NewMCPServer(runDebugNodeCommand RunDebugNodeCommandFuncType, cfg Config) (*MCPServer, error) {
+	if runDebugNodeCommand == nil {
+		return nil, fmt.Errorf("function to run debug node command is nil")
 	}
+	return &MCPServer{
+		runDebugNodeCommand: runDebugNodeCommand,
+		cfg:                 cfg,
+	}, nil
 }
 
 // AddTools registers all kernel-related MCP tools
@@ -39,6 +44,7 @@ func (s *MCPServer) AddTools(server *mcp.Server) {
 			              Use this command to discover a list of all (or a filtered selection of) currently tracked connections.
 Parameters:
 - node (required): Name of the node from where conntrack entries are expected to be extracted
+- namespace (optional): Namespace of the debug pod from where conntrack entries are expected to be extracted. Default: 'default'
 - command (optional): These options specify the particular operation to perform. These options can only be used if configured image has 'conntrack' utility available.
 					  -L, --dump : List connection tracking table.
 					  -C, --count: Show the table counter.
@@ -53,14 +59,16 @@ Parameters:
 - tail (optional): Return only last N lines
 - apply_tail_first (optional): If both head and tail are set and apply_tail_first is true,
 apply tail before head. Default: false
+- timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 
 Example:
 - node='ovn-control-plane', command='-L'
+- node='ovn-worker', namespace='ovn-kubernetes', command='-L'
 - node='ovn-worker', filter_parameters='-s 1.2.3.4 -d 5.6.7.8 -p tcp --sport 32000 --dport 10250'
 
 Example output:
 tcp 6 91 ESTABLISHED src=1.2.3.4 dst=5.6.7.8 sport=32000 dport=10250 src=5.6.7.8 dst=1.2.3.4  sport=10250 dport=32000 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=2
-`, defaultMaxOutputLines),
+`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetConntrack)
 	// get-iptables tool registration
 	mcp.AddTool(server,
@@ -70,6 +78,7 @@ tcp 6 91 ESTABLISHED src=1.2.3.4 dst=5.6.7.8 sport=32000 dport=10250 src=5.6.7.8
 			              Iptables and ip6tables are used to inspect the tables of IPv4 and IPv6 packet filter rules in the Linux kernel.
 Parameters:
 - node (required): Name of the node from where packet filter rules are expected to be extracted
+- namespace (optional): Namespace of the debug pod from where packet filter rules are expected to be extracted. Default: 'default'
 - table (optional): There are currently five independent tables (which tables are present at any time depends on the kernel configuration options and which modules are present).
                     filter	: This is the default table
 					nat   	: This  table is consulted when a packet that creates a new connection is encountered.
@@ -91,6 +100,7 @@ Parameters:
 - tail (optional): Return only last N lines
 - apply_tail_first (optional): If both head and tail are set and apply_tail_first is true,
 apply tail before head. Default: false
+- timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 							
 Example:
 - node='ovn-control-plane', table='nat', command='-L', filter_parameters='-nv4'	
@@ -98,7 +108,7 @@ Example output:
 Chain POSTROUTING (policy ACCEPT 675K packets, 41M bytes)
  pkts bytes target     prot opt in     out     source               destination         
  675K   41M OVN-KUBE-EGRESS-IP-MULTI-NIC  all  --  *      *       0.0.0.0/0            0.0.0.0/0     							
-`, defaultMaxOutputLines),
+`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetIptables)
 	// get-nft tool registration
 	mcp.AddTool(server,
@@ -107,6 +117,7 @@ Chain POSTROUTING (policy ACCEPT 675K packets, 41M bytes)
 			Description: fmt.Sprintf(`get-nft allows to interact with kernel to list packet filtering and classification rules.
 Parameters:
 - node (required): Name of the node from where packet filtering and classification rules are expected to be extracted
+- namespace (optional): Namespace of the debug pod from where packet filtering and classification rules are expected to be extracted. Default: 'default'
 - command (required): These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below.
                     - list ruleset   : The ruleset keyword is used to identify the whole set of tables, chains, etc. Print the ruleset in human-readable format.
 					- list tables    : List all chains and rules of the specified table.
@@ -126,12 +137,13 @@ Parameters:
 - tail (optional): Return only last N lines
 - apply_tail_first (optional): If both head and tail are set and apply_tail_first is true,
 apply tail before head. Default: false
+- timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 					
 Example:
 - node='ovn-control-plane', command='list tables', address_families='inet'
 Example output:
 table inet ovn-kubernetes
-`, defaultMaxOutputLines),
+`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetNFT)
 	// get-ip tool registration
 	mcp.AddTool(server,
@@ -140,6 +152,7 @@ table inet ovn-kubernetes
 			Description: fmt.Sprintf(`get-ip allows to interact with kernel to list routing, network devices, interfaces.
 Parameters:
 - node (required): Name of the node on which ip command is expected to be executed
+- namespace (optional): Namespace of the debug pod on which ip command is expected to be executed. Default: 'default'
 - options (optional): These options helps in providing more details or formattig output data.
                       -d, -details        : Output more detailed information.
 					  -4                  : shortcut for -family inet.
@@ -163,33 +176,33 @@ Parameters:
 - tail (optional): Return only last N lines
 - apply_tail_first (optional): If both head and tail are set and apply_tail_first is true,
 apply tail before head. Default: false
+- timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 
 Example:
 - node='ovn-control-plane', options="-4", command='route show', filter_parameters='table all'
 Example output:
 default via 10.0.0.254 dev br-ex proto dhcp src 10.0.0.10 metric 48
-`, defaultMaxOutputLines),
+`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetIPCommandOutput)
 }
 
 // executeCommand executes a command on a node via kubectl debug
-func (s *MCPServer) executeCommand(ctx context.Context, req *mcp.CallToolRequest, node string, command []string) (string, error) {
-	debugParameter := k8stypes.DebugNodeParams{Name: node, Image: s.cfg.Image, Command: command}
-	_, result, err := s.k8sMcpServer.DebugNode(ctx, req, debugParameter)
+func (s *MCPServer) executeCommand(ctx context.Context, namespace, node string, command []string) (string, error) {
+	stdout, stderr, err := s.runDebugNodeCommand(ctx, namespace, node, s.cfg.Image, command, "", "", 0)
 	if err != nil {
 		return "", fmt.Errorf("error while establishing tty connection to the node: %w", err)
 	}
 
 	// Filter out warning lines from stderr
-	if result.Stderr != "" {
-		stderr := filterWarnings(result.Stderr)
+	if stderr != "" {
+		stderr := filterWarnings(stderr)
 		if stderr != "" {
 			return "", fmt.Errorf("error while running command: %s", stderr)
 		}
 	}
 
 	// Filter out warning lines from stdout
-	stdout := filterWarnings(result.Stdout)
+	stdout = filterWarnings(stdout)
 
 	return stdout, nil
 }

--- a/pkg/kernel/mcp/nft.go
+++ b/pkg/kernel/mcp/nft.go
@@ -15,7 +15,14 @@ import (
 // GetNFT MCP handler for nftables operations.
 // GetNFT retrieves nftables configuration from a Kubernetes node.
 func (s *MCPServer) GetNFT(ctx context.Context, req *mcp.CallToolRequest, in types.ListNFTParams) (*mcp.CallToolResult, types.Result, error) {
-	err := s.utilityExists(ctx, req, in.Node, "nft")
+	// If timeout is specified, create a new context with timeout
+	var cancel context.CancelFunc
+	ctx, cancel = in.TimeoutParams.WithTimeout(ctx)
+	if cancel != nil {
+		defer cancel()
+	}
+
+	err := s.utilityExists(ctx, in.Namespace, in.Node, "nft")
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting nft data: failed to verify nft utility availability in configured image: %w", err)
 	}
@@ -36,7 +43,7 @@ func (s *MCPServer) GetNFT(ctx context.Context, req *mcp.CallToolRequest, in typ
 	cmd.Add(strings.Fields(command)...)
 	cmd.AddIf(addressFamilies != "", addressFamilies)
 
-	stdout, err := s.executeCommand(ctx, req, in.Node, cmd.Build())
+	stdout, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting nft data: %w", err)
 	}

--- a/pkg/kernel/mcp/util.go
+++ b/pkg/kernel/mcp/util.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/commandbuilder"
 )
 
@@ -16,14 +14,13 @@ const (
 )
 
 // utilityExists checks if a utility/command exists in the container
-func (s *MCPServer) utilityExists(ctx context.Context, req *mcp.CallToolRequest, node, utility string) error {
+func (s *MCPServer) utilityExists(ctx context.Context, namespace, node, utility string) error {
 	cmd := commandbuilder.NewCommand(utility, "-V")
-	debugParameter := k8stypes.DebugNodeParams{Name: node, Image: s.cfg.Image, Command: cmd.Build()}
-	_, result, err := s.k8sMcpServer.DebugNode(ctx, req, debugParameter)
+	_, stderr, err := s.runDebugNodeCommand(ctx, namespace, node, s.cfg.Image, cmd.Build(), "", "", 0)
 	if err != nil {
 		return fmt.Errorf("error while checking availability of the utility %s: %w", utility, err)
 	}
-	stderr := strings.TrimSpace(filterWarnings(result.Stderr))
+	stderr = strings.TrimSpace(filterWarnings(stderr))
 	if stderr != "" {
 		return fmt.Errorf("utility %s is unavailable in configured image: %s", utility, stderr)
 	}

--- a/pkg/kernel/types/types.go
+++ b/pkg/kernel/types/types.go
@@ -1,12 +1,17 @@
 package types
 
-import "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+import (
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/timeout"
+)
 
 // CommonParams contains the common parameters required for executing kernel commands on a Kubernetes node.
 // These parameters are embedded in other specific parameter types.
 type CommonParams struct {
-	Node string `json:"node"` // Node is the name of the Kubernetes node where the command will be executed
+	Node      string `json:"node"`                // Node is the name of the Kubernetes node where the command will be executed
+	Namespace string `json:"namespace,omitempty"` // Namespace is the namespace of the Kubernetes node where the command will be executed
 	headtail.HeadTailParams
+	timeout.TimeoutParams
 }
 
 // ListConntrackParams contains parameters for listing connection tracking entries using conntrack command.

--- a/pkg/kubernetes/client/nodes.go
+++ b/pkg/kubernetes/client/nodes.go
@@ -6,14 +6,40 @@ import (
 	"log"
 	"time"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 )
 
-func (c *OVNKMCPServerClientSet) DebugNode(ctx context.Context, name, image string, command []string, hostPath, mountPath string) (string, string, error) {
-	namespace := metav1.NamespaceDefault
+func (c *OVNKMCPServerClientSet) DebugNode(ctx context.Context, namespace, name, image string, command []string, hostPath, mountPath string, timeout time.Duration) (string, string, error) {
+	// Validate name
+	if name == "" {
+		return "", "", fmt.Errorf("node name is required")
+	}
+
+	// Validate paths before creating the pod
+	if err := utils.ValidatePath(hostPath, "hostPath", true); err != nil {
+		return "", "", err
+	}
+
+	if err := utils.ValidatePath(mountPath, "mountPath", true); err != nil {
+		return "", "", err
+	}
+
+	// If namespace is not provided, use the default namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+
+	// If timeout is specified, create a new context with timeout
+	if timeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	debugPodName, cleanupPod, err := c.createPod(ctx, name, namespace, image, hostPath, mountPath)
 	if err != nil {
 		return "", "", err
@@ -110,8 +136,12 @@ func (c *OVNKMCPServerClientSet) createPod(ctx context.Context, node, namespace,
 	}
 
 	cleanupPod := func() {
+		// Create a new context with a timeout of 10 seconds to delete the pod.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
 		// Delete the pod.
-		err := c.clientSet.CoreV1().Pods(namespace).Delete(ctx, createdDebugPod.Name, metav1.DeleteOptions{})
+		err := c.clientSet.CoreV1().Pods(namespace).Delete(cleanupCtx, createdDebugPod.Name, metav1.DeleteOptions{})
 		if err != nil {
 			log.Printf("failed to cleanup debug pod: %v", err)
 		}

--- a/pkg/kubernetes/client/pods.go
+++ b/pkg/kubernetes/client/pods.go
@@ -71,7 +71,7 @@ func (c *OVNKMCPServerClientSet) ExecPod(ctx context.Context, name, namespace, c
 	stdout := bytes.NewBuffer(make([]byte, 0))
 	stderr := bytes.NewBuffer(make([]byte, 0))
 
-	err = c.podExecutor.Execute(req.URL(), c.config, nil, stdout, stderr, false, nil)
+	err = c.podExecutor.ExecuteWithContext(ctx, req.URL(), c.config, nil, stdout, stderr, false, nil)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to execute command %v in pod: %w", command, err)
 	}

--- a/pkg/kubernetes/mcp/nodes.go
+++ b/pkg/kubernetes/mcp/nodes.go
@@ -2,27 +2,26 @@ package mcp
 
 import (
 	"context"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
-	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
 )
 
-// DebugNode debugs a node by name, image and command.
+// DebugNode debugs a node by name, by using a debug pod in a namespace, with an image and command.
 func (s *MCPServer) DebugNode(ctx context.Context, req *mcp.CallToolRequest, in types.DebugNodeParams) (*mcp.CallToolResult, types.DebugNodeResult, error) {
-	// Validate paths before creating the pod
-	if err := utils.ValidatePath(in.HostPath, "hostPath", true); err != nil {
-		return nil, types.DebugNodeResult{}, err
-	}
+	// Convert timeout seconds to duration
+	timeout := in.TimeoutParams.ToDuration()
 
-	if err := utils.ValidatePath(in.MountPath, "mountPath", true); err != nil {
-		return nil, types.DebugNodeResult{}, err
-	}
-
-	stdout, stderr, err := s.clientSet.DebugNode(ctx, in.Name, in.Image, in.Command, in.HostPath, in.MountPath)
+	stdout, stderr, err := s.clientSet.DebugNode(ctx, in.Namespace, in.Name, in.Image, in.Command, in.HostPath, in.MountPath, timeout)
 	if err != nil {
 		return nil, types.DebugNodeResult{}, err
 	}
 
 	return nil, types.DebugNodeResult{Stdout: stdout, Stderr: stderr}, nil
+}
+
+// RunDebugNode runs a debug node pod on the given node by name, namespace, image and command.
+func (s *MCPServer) RunDebugNode(ctx context.Context, namespace string, nodeName string, image string, command []string, hostPath string, mountPath string, timeout time.Duration) (string, string, error) {
+	return s.clientSet.DebugNode(ctx, namespace, nodeName, image, command, hostPath, mountPath, timeout)
 }

--- a/pkg/kubernetes/types/nodes.go
+++ b/pkg/kubernetes/types/nodes.go
@@ -1,12 +1,16 @@
 package types
 
-// DebugNodeParams is a type that contains the name, image and command of a node.
+import "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/timeout"
+
+// DebugNodeParams is a type that contains the namespace, name, image, command, host path, mount path
+// of a node along with  timeout parameters to be used for the command execution.
 type DebugNodeParams struct {
-	Name      string   `json:"name"`
+	NamespacedNameParams
 	Image     string   `json:"image"`
 	Command   []string `json:"command"`
 	HostPath  string   `json:"host_path,omitempty"`
 	MountPath string   `json:"mount_path,omitempty"`
+	timeout.TimeoutParams
 }
 
 // DebugNodeResult is a type that contains the stdout and stderr of the executed command.

--- a/pkg/middleware/timeout/timeout.go
+++ b/pkg/middleware/timeout/timeout.go
@@ -2,14 +2,18 @@ package timeout
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/timeout"
 )
 
-// ToolTimeout returns an MCP receiving middleware that applies a context
-// timeout to every tools/call request. This ensures all tool operations
-// have a bounded execution time without requiring per-tool code.
+// ToolTimeout returns an MCP receiving middleware that applies the default
+// context timeout to a tools/call request only when the request does not
+// carry a non-zero timeout parameter. When the tool has a non-zero timeout
+// parameter, the middleware leaves the context unchanged and the tool
+// handler is responsible for enforcing that per-request timeout.
 func ToolTimeout(timeout time.Duration) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
@@ -17,11 +21,34 @@ func ToolTimeout(timeout time.Duration) mcp.Middleware {
 				return next(ctx, method, req)
 			}
 
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, timeout)
-			defer cancel()
+			// Get the timeout parameters from the request.
+			timeoutParam := getTimeoutParams(req)
+
+			// If the timeout parameter is 0, apply the default timeout.
+			if timeoutParam == 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, timeout)
+				defer cancel()
+			}
 
 			return next(ctx, method, req)
 		}
 	}
+}
+
+// getTimeoutParams extracts the timeout parameters from the request.
+// If timeout parameter cannot be extracted, return 0.
+func getTimeoutParams(req mcp.Request) time.Duration {
+	if req == nil {
+		return 0
+	}
+	p, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+	if !ok || p == nil {
+		return 0
+	}
+	var timeoutParams timeout.TimeoutParams
+	if err := json.Unmarshal(p.Arguments, &timeoutParams); err != nil {
+		return 0
+	}
+	return timeoutParams.ToDuration()
 }

--- a/pkg/middleware/timeout/timeout_test.go
+++ b/pkg/middleware/timeout/timeout_test.go
@@ -2,10 +2,12 @@ package timeout
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/timeout"
 )
 
 func TestToolTimeout(t *testing.T) {
@@ -71,6 +73,57 @@ func TestToolTimeout(t *testing.T) {
 		_, err := handler(context.Background(), "tools/call", nil)
 		if err != nil {
 			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("tools timeout parameter is respected and context is not changed", func(t *testing.T) {
+		m := ToolTimeout(10 * time.Millisecond)
+
+		var capturedCtx context.Context
+		handler := m(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			capturedCtx = ctx
+			return nil, nil
+		})
+
+		arguments, err := json.Marshal(timeout.TimeoutParams{TimeoutSeconds: 5})
+		if err != nil {
+			t.Fatalf("marshalling timeout parameters: %v", err)
+		}
+		req := &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{
+				Arguments: arguments,
+			},
+		}
+
+		_, _ = handler(context.Background(), "tools/call", req)
+
+		_, ok := capturedCtx.Deadline()
+		if ok {
+			t.Fatal("expected context to not have changed for the tool with non-zero timeout parameter")
+		}
+	})
+
+	t.Run("when tools timeout parameter is 0, default timeout is applied", func(t *testing.T) {
+		m := ToolTimeout(10 * time.Millisecond)
+
+		handler := m(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			time.Sleep(50 * time.Millisecond)
+			return nil, ctx.Err()
+		})
+
+		arguments, err := json.Marshal(timeout.TimeoutParams{TimeoutSeconds: 0})
+		if err != nil {
+			t.Fatalf("marshalling timeout parameters: %v", err)
+		}
+		req := &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{
+				Arguments: arguments,
+			},
+		}
+
+		_, err = handler(context.Background(), "tools/call", req)
+		if err != context.DeadlineExceeded {
+			t.Fatalf("expected DeadlineExceeded, got: %v", err)
 		}
 	})
 }

--- a/pkg/network-tools/mcp/mcp.go
+++ b/pkg/network-tools/mcp/mcp.go
@@ -1,24 +1,45 @@
 package mcp
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	kubernetesmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/timeout"
 )
+
+type RunDebugNodeCommandFuncType func(ctx context.Context, namespace string, nodeName string, image string, command []string, hostPath string, mountPath string, timeout time.Duration) (string, string, error)
+type RunPodExecCommandFuncType func(ctx context.Context, namespace, name, container string, command []string) (string, string, error)
+
+// Config contains the configuration for the network tools MCP server.
+type Config struct {
+	// PwruImage is the container image to use for running the pwru command on the node.
+	PwruImage string
+	// TcpdumpImage is the container image to use for running the tcpdump command on the node.
+	TcpdumpImage string
+}
 
 // MCPServer provides MCP server functionality for network tools operations.
 type MCPServer struct {
-	k8sMcpServer *kubernetesmcp.MCPServer
-	pwruImage    string
-	tcpdumpImage string
+	runDebugNodeCommand RunDebugNodeCommandFuncType
+	runPodExecCommand   RunPodExecCommandFuncType
+	cfg                 Config
 }
 
 // NewMCPServer creates a new MCP server instance
-func NewMCPServer(k8sMcpServer *kubernetesmcp.MCPServer, pwruImage, tcpdumpImage string) *MCPServer {
-	return &MCPServer{
-		k8sMcpServer: k8sMcpServer,
-		pwruImage:    pwruImage,
-		tcpdumpImage: tcpdumpImage,
+func NewMCPServer(runNodeCommand RunDebugNodeCommandFuncType, runPodExecCommand RunPodExecCommandFuncType, cfg Config) (*MCPServer, error) {
+	if runNodeCommand == nil {
+		return nil, fmt.Errorf("function to run debug node command is nil")
 	}
+	if runPodExecCommand == nil {
+		return nil, fmt.Errorf("function to run pod exec command is nil")
+	}
+	return &MCPServer{
+		runDebugNodeCommand: runNodeCommand,
+		runPodExecCommand:   runPodExecCommand,
+		cfg:                 cfg,
+	}, nil
 }
 
 // AddTools registers network tools with the MCP server
@@ -26,7 +47,7 @@ func (s *MCPServer) AddTools(server *mcp.Server) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name: "tcpdump",
-			Description: `Capture network packets on a node or inside a pod with strict safety controls.
+			Description: fmt.Sprintf(`Capture network packets on a node or inside a pod with strict safety controls.
 
 Supports both node-level and pod-level packet capture with BPF filtering.
 
@@ -37,6 +58,7 @@ The image must contain the tcpdump utility
 Parameters:
 - target_type: 'node' or 'pod' (required)
 - node_name: Name of the node (required when target_type is 'node')
+- node_pod_namespace (optional): Namespace of the debug pod on which the command is expected to be executed when target_type is 'node'. Default: 'default'
 - pod_name: Name of the pod (required when target_type is 'pod')
 - pod_namespace: Namespace of the pod (required when target_type is 'pod')
 - container_name: Name of the container in the pod (optional, uses default container if not specified)
@@ -44,16 +66,18 @@ Parameters:
 - packet_count: Number of packets to capture (default: 100, max: 1000)
 - bpf_filter: BPF filter expression to match packets (optional, e.g., "tcp and dst port 8080", "host 10.0.0.1")
 - snaplen: Snapshot length in bytes (default: 96, max: 1500)
+- timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 
 Examples:
 - Capture on node: {"target_type": "node", "node_name": "worker-1", "interface": "eth0", "packet_count": 100, "bpf_filter": "tcp port 80"}
 - Capture in pod: {"target_type": "pod", "pod_name": "my-pod", "pod_namespace": "default", "interface": "eth0", "packet_count": 100, "bpf_filter": "host 10.0.0.1"}
 - Capture DNS: {"target_type": "node", "node_name": "worker-1", "interface": "any", "packet_count": 50, "bpf_filter": "port 53"}`,
+				int(timeout.MaxTimeout.Seconds())),
 		}, s.Tcpdump)
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name: "pwru",
-			Description: `Trace packets through the Linux kernel networking stack using eBPF.
+			Description: fmt.Sprintf(`Trace packets through the Linux kernel networking stack using eBPF.
 
 pwru (packet, where are you?) shows which kernel functions process a packet, helping debug packet
 drops, routing issues, and understanding the kernel's packet processing path.
@@ -65,12 +89,15 @@ The image must contain the pwru utility
 
 Parameters:
 - node_name: Name of the node to run pwru on (required)
+- node_pod_namespace (optional): Namespace of the debug pod on which the command is expected to be executed. Default: 'default'
 - bpf_filter: BPF filter expression to match packets (optional, e.g., "tcp and dst port 8080", "host 10.0.0.1")
 - output_limit_lines: Maximum number of trace events to capture (default: 100, max: 1000)
+- timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 
 Examples:
 - Basic trace: {"node_name": "worker-1", "bpf_filter": "host 10.244.0.5", "output_limit_lines": 100}
 - TCP traffic: {"node_name": "worker-1", "bpf_filter": "tcp and dst port 8080", "output_limit_lines": 50}
 - ICMP packets: {"node_name": "worker-1", "bpf_filter": "icmp", "output_limit_lines": 100}`,
+				int(timeout.MaxTimeout.Seconds())),
 		}, s.Pwru)
 }

--- a/pkg/network-tools/mcp/pwru.go
+++ b/pkg/network-tools/mcp/pwru.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/network-tools/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/commandbuilder"
 )
@@ -35,17 +34,16 @@ func (s *MCPServer) Pwru(ctx context.Context, req *mcp.CallToolRequest, in types
 	// pwru accepts pcap filter as positional argument(s)
 	cmd.AddIfNotEmpty(in.BPFFilter, in.BPFFilter)
 
-	target := k8stypes.DebugNodeParams{
-		Name:      in.NodeName,
-		Image:     s.pwruImage,
-		HostPath:  "/sys/kernel/debug",
-		MountPath: "/sys/kernel/debug",
-		Command:   cmd.Build(),
+	// If timeout is specified, create a new context with timeout
+	var cancel context.CancelFunc
+	ctx, cancel = in.TimeoutParams.WithTimeout(ctx)
+	if cancel != nil {
+		defer cancel()
 	}
 
-	result, err := s.runDebugNode(ctx, req, target)
+	stdout, stderr, err := s.runDebugNodeCommand(ctx, in.NodePodNamespace, in.NodeName, s.cfg.PwruImage, cmd.Build(), "/sys/kernel/debug", "/sys/kernel/debug", 0)
 	if err != nil {
 		return nil, types.CommandResult{}, err
 	}
-	return nil, result, nil
+	return nil, types.CommandResult{Output: stdout, Stderr: stderr}, nil
 }

--- a/pkg/network-tools/mcp/tcpdump.go
+++ b/pkg/network-tools/mcp/tcpdump.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/network-tools/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/commandbuilder"
 )
@@ -53,30 +52,26 @@ func (s *MCPServer) Tcpdump(ctx context.Context, req *mcp.CallToolRequest, in ty
 	cmd.AddIfNotEmpty(in.Interface, "-i", in.Interface)
 	cmd.AddIfNotEmpty(in.BPFFilter, in.BPFFilter)
 
+	// If timeout is specified, create a new context with timeout
+	var cancel context.CancelFunc
+	ctx, cancel = in.TimeoutParams.WithTimeout(ctx)
+	if cancel != nil {
+		defer cancel()
+	}
+
 	switch in.TargetType {
 	case "node":
-		result, err := s.runDebugNode(ctx, req, k8stypes.DebugNodeParams{
-			Name:    in.NodeName,
-			Image:   s.tcpdumpImage,
-			Command: cmd.Build(),
-		})
+		stdout, stderr, err := s.runDebugNodeCommand(ctx, in.NodePodNamespace, in.NodeName, s.cfg.TcpdumpImage, cmd.Build(), "", "", 0)
 		if err != nil {
 			return nil, types.CommandResult{}, err
 		}
-		return nil, result, nil
+		return nil, types.CommandResult{Output: stdout, Stderr: stderr}, nil
 	case "pod":
-		result, err := s.runExecPod(ctx, req, k8stypes.ExecPodParams{
-			NamespacedNameParams: k8stypes.NamespacedNameParams{
-				Name:      in.PodName,
-				Namespace: in.PodNamespace,
-			},
-			Container: in.ContainerName,
-			Command:   cmd.Build(),
-		})
+		stdout, stderr, err := s.runPodExecCommand(ctx, in.PodNamespace, in.PodName, in.ContainerName, cmd.Build())
 		if err != nil {
 			return nil, types.CommandResult{}, err
 		}
-		return nil, result, nil
+		return nil, types.CommandResult{Output: stdout, Stderr: stderr}, nil
 	default:
 		return nil, types.CommandResult{}, fmt.Errorf("invalid target_type: %s (must be 'node' or 'pod')", in.TargetType)
 	}

--- a/pkg/network-tools/mcp/utils.go
+++ b/pkg/network-tools/mcp/utils.go
@@ -1,47 +1,13 @@
 package mcp
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	k8stypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kubernetes/types"
-	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/network-tools/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
 )
 
 var interfaceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
-
-// runDebugNode runs a command on a node
-func (s *MCPServer) runDebugNode(ctx context.Context, req *mcp.CallToolRequest, target k8stypes.DebugNodeParams) (types.CommandResult, error) {
-	if target.Name == "" {
-		return types.CommandResult{}, fmt.Errorf("node's name is required when target type is 'node'")
-	}
-	if target.Image == "" {
-		return types.CommandResult{}, fmt.Errorf("node's image is required when target type is 'node'")
-	}
-	_, output, err := s.k8sMcpServer.DebugNode(ctx, req, target)
-	if err != nil {
-		return types.CommandResult{}, err
-	}
-	return types.CommandResult{Output: output.Stdout}, nil
-}
-
-// runExecPod runs a command on a pod
-func (s *MCPServer) runExecPod(ctx context.Context, req *mcp.CallToolRequest, target k8stypes.ExecPodParams) (types.CommandResult, error) {
-	if target.Name == "" {
-		return types.CommandResult{}, fmt.Errorf("pod's name is required when target type is 'pod'")
-	}
-	if target.Namespace == "" {
-		target.Namespace = "default"
-	}
-	_, output, err := s.k8sMcpServer.ExecPod(ctx, req, target)
-	if err != nil {
-		return types.CommandResult{}, err
-	}
-	return types.CommandResult{Output: output.Stdout}, nil
-}
 
 // validateInterface validates a network interface name for security and correctness.
 func validateInterface(iface string) error {

--- a/pkg/network-tools/types/manifest.go
+++ b/pkg/network-tools/types/manifest.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/timeout"
+
 // BaseNetworkDiagParams contains common parameters shared across network diagnostic tools.
 type BaseNetworkDiagParams struct {
 	BPFFilter string `json:"bpf_filter,omitempty"`
@@ -13,7 +15,8 @@ type TcpdumpParams struct {
 	TargetType string `json:"target_type"`
 
 	// Node-specific fields
-	NodeName string `json:"node_name,omitempty"`
+	NodeName         string `json:"node_name,omitempty"`
+	NodePodNamespace string `json:"node_pod_namespace,omitempty"`
 
 	// Pod-specific fields
 	PodName       string `json:"pod_name,omitempty"`
@@ -23,6 +26,8 @@ type TcpdumpParams struct {
 	Interface   string `json:"interface,omitempty"`
 	PacketCount int    `json:"packet_count,omitempty"`
 	Snaplen     int    `json:"snaplen,omitempty"`
+
+	timeout.TimeoutParams
 }
 
 // PwruParams contains parameters for running pwru (packet, where are you?) eBPF-based
@@ -31,12 +36,14 @@ type PwruParams struct {
 	BaseNetworkDiagParams
 
 	NodeName         string `json:"node_name"`
+	NodePodNamespace string `json:"node_pod_namespace,omitempty"`
 	OutputLimitLines int    `json:"output_limit_lines,omitempty"`
+
+	timeout.TimeoutParams
 }
 
 // CommandResult represents the output and status of an executed command.
 type CommandResult struct {
-	Output   string `json:"output"`
-	ExitCode int    `json:"exit_code,omitempty"`
-	Error    string `json:"error,omitempty"`
+	Output string `json:"output"`
+	Stderr string `json:"stderr,omitempty"`
 }

--- a/pkg/utils/timeout/timeout.go
+++ b/pkg/utils/timeout/timeout.go
@@ -1,0 +1,33 @@
+package timeout
+
+import (
+	"context"
+	"time"
+)
+
+// MaxTimeout is the maximum timeout in seconds for the command execution.
+const MaxTimeout = 300 * time.Second
+
+// TimeoutParams is a type that contains the timeout seconds for the command execution.
+type TimeoutParams struct {
+	// TimeoutSeconds is the timeout in seconds for the command execution.
+	// If not specified, server default timeout is used. The maximum value
+	// is MaxTimeout.
+	TimeoutSeconds uint32 `json:"timeout_seconds,omitempty"`
+}
+
+// ToDuration converts the timeout seconds to a duration. The maximum value
+// is MaxTimeout.
+func (t *TimeoutParams) ToDuration() time.Duration {
+	duration := time.Duration(t.TimeoutSeconds) * time.Second
+	return min(duration, MaxTimeout)
+}
+
+// WithTimeout returns a context with a timeout set to the timeout seconds. If the timeout is 0,
+// the original context is returned and the cancel function is nil.
+func (t *TimeoutParams) WithTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if t.TimeoutSeconds == 0 {
+		return ctx, nil
+	}
+	return context.WithTimeout(ctx, t.ToDuration())
+}

--- a/pkg/utils/timeout/timeout_test.go
+++ b/pkg/utils/timeout/timeout_test.go
@@ -1,0 +1,70 @@
+package timeout
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestTimeoutParams_ToDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout TimeoutParams
+		want    time.Duration
+	}{
+		{name: "timeout is 0", timeout: TimeoutParams{TimeoutSeconds: 0}, want: 0},
+		{name: "timeout is 1", timeout: TimeoutParams{TimeoutSeconds: 1}, want: 1 * time.Second},
+		{name: "timeout is 10", timeout: TimeoutParams{TimeoutSeconds: 10}, want: 10 * time.Second},
+		{name: "timeout is max", timeout: TimeoutParams{TimeoutSeconds: uint32(MaxTimeout.Seconds())}, want: MaxTimeout},
+		{name: "timeout is just over max", timeout: TimeoutParams{TimeoutSeconds: uint32(MaxTimeout.Seconds()) + 1}, want: MaxTimeout},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.timeout.ToDuration()
+			if got != test.want {
+				t.Fatalf("expected %v, but got %v", test.want, got)
+			}
+		})
+	}
+}
+
+func TestTimeoutParams_WithTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout TimeoutParams
+	}{
+		{name: "timeout is 0", timeout: TimeoutParams{TimeoutSeconds: 0}},
+		{name: "timeout is 1", timeout: TimeoutParams{TimeoutSeconds: 1}},
+		{name: "timeout is 10", timeout: TimeoutParams{TimeoutSeconds: 10}},
+		{name: "timeout is max", timeout: TimeoutParams{TimeoutSeconds: uint32(MaxTimeout.Seconds())}},
+		{name: "timeout is just over max", timeout: TimeoutParams{TimeoutSeconds: uint32(MaxTimeout.Seconds()) + 1}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, cancel := test.timeout.WithTimeout(ctx)
+			if cancel != nil {
+				defer cancel()
+			}
+			if cancel != nil {
+				if _, ok := ctx.Deadline(); !ok {
+					t.Fatal("expected context to have a deadline")
+				}
+
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("expected context to have a deadline, but it doesn't")
+				}
+
+				if time.Until(deadline) > test.timeout.ToDuration() {
+					t.Fatal("expected context to have a deadline within the timeout duration")
+				}
+			} else {
+				if _, ok := ctx.Deadline(); ok {
+					t.Fatal("expected context to not have a deadline, but it does")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added support of namespace and timeout paramaters for node debug. The tools which use node debug are also refactored. Additionally, the timeout middleware is updated to respect individual tools' timeout value, if specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-request `timeout_seconds` support across kernel operations and network diagnostic tools.
  * Added `namespace` support for kernel-level command execution.
  * Added `node_pod_namespace` parameter to network tools (optional, defaults to `default`).

* **Improvements**
  * Improved timeout behavior: explicit per-call timeouts are respected; default timeouts apply only when no per-call value is set.
  * Updated tool availability checks and command execution to honor request context.
  * Network-tools responses now return only `output` and `stderr` (removed `exit_code` and `error`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->