### PR TITLE
Split conntrack summary from stderr and append to output

### DIFF
--- a/pkg/kernel/mcp/conntrack.go
+++ b/pkg/kernel/mcp/conntrack.go
@@ -58,7 +58,7 @@ func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, 
 	// Strip empty lines from the output
 	lines := utils.StripEmptyLines(strings.Split(stdout, "\n"))
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxOutputLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxOutputLines)
 	// Join the lines back into a single string
 	stdout = strings.Join(lines, "\n")
 	// If conntrack summary is present, add it to the output

--- a/pkg/kernel/mcp/conntrack.go
+++ b/pkg/kernel/mcp/conntrack.go
@@ -36,14 +36,23 @@ func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, 
 		return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
 	}
 
-	var stdout string
+	var stdout, stderr, summary string
 	if !conntrackCliAvailable {
-		stdout, err = s.getConntrackFromFile(ctx, in.Namespace, in.Node)
+		stdout, stderr, err = s.getConntrackFromFile(ctx, in.Namespace, in.Node)
 	} else {
-		stdout, err = s.getConntrackUsingCLI(ctx, in.Namespace, in.Node, strings.TrimSpace(in.Command), in.FilterParameters)
+		stdout, stderr, err = s.getConntrackUsingCLI(ctx, in.Namespace, in.Node, strings.TrimSpace(in.Command), in.FilterParameters)
 	}
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting list of conntrack entries: %w", err)
+	}
+
+	if stderr != "" {
+		// Split the stderr into summary and remaining stderr
+		remainingStderr := ""
+		summary, remainingStderr = splitConntrackSummary(stderr)
+		if remainingStderr != "" {
+			return nil, types.Result{}, fmt.Errorf("error while running command: %s", remainingStderr)
+		}
 	}
 
 	// Strip empty lines from the output
@@ -52,11 +61,15 @@ func (s *MCPServer) GetConntrack(ctx context.Context, req *mcp.CallToolRequest, 
 	lines = in.HeadTailParams.Apply(lines, defaultMaxOutputLines)
 	// Join the lines back into a single string
 	stdout = strings.Join(lines, "\n")
+	// If conntrack summary is present, add it to the output
+	if summary != "" {
+		stdout = fmt.Sprintf("%s\n -- conntrack summary --\n%s", stdout, summary)
+	}
 	return nil, types.Result{Data: stdout}, nil
 }
 
 // getConntrackUsingCLI executes conntrack CLI commands.
-func (s *MCPServer) getConntrackUsingCLI(ctx context.Context, namespace, node, command, filterParameters string) (string, error) {
+func (s *MCPServer) getConntrackUsingCLI(ctx context.Context, namespace, node, command, filterParameters string) (string, string, error) {
 	cmd := commandbuilder.NewCommand("conntrack")
 	switch command {
 	case "-L", "--dump":
@@ -75,7 +88,7 @@ func (s *MCPServer) getConntrackUsingCLI(ctx context.Context, namespace, node, c
 
 // getConntrackFromFile parses /proc/net/nf_conntrack directly.
 // TODO: Add filter support while getting conntrack entries from /proc/net/nf_conntrack.
-func (s *MCPServer) getConntrackFromFile(ctx context.Context, namespace, node string) (string, error) {
+func (s *MCPServer) getConntrackFromFile(ctx context.Context, namespace, node string) (string, string, error) {
 	cmd := commandbuilder.NewCommand("cat")
 	cmd.Add(conntrackSystemFile)
 	return s.executeCommand(ctx, namespace, node, cmd.Build())

--- a/pkg/kernel/mcp/ip.go
+++ b/pkg/kernel/mcp/ip.go
@@ -55,7 +55,7 @@ func (s *MCPServer) GetIPCommandOutput(ctx context.Context, req *mcp.CallToolReq
 	// Strip empty lines from the output
 	lines := utils.StripEmptyLines(strings.Split(stdout, "\n"))
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxOutputLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxOutputLines)
 	// Join the lines back into a single string
 	stdout = strings.Join(lines, "\n")
 	return nil, types.Result{Data: stdout}, nil

--- a/pkg/kernel/mcp/ip.go
+++ b/pkg/kernel/mcp/ip.go
@@ -43,9 +43,13 @@ func (s *MCPServer) GetIPCommandOutput(ctx context.Context, req *mcp.CallToolReq
 	cmd.Add(strings.Fields(in.Command)...)
 	cmd.AddIfNotEmpty(in.FilterParameters, strings.Fields(in.FilterParameters)...)
 
-	stdout, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
+	stdout, stderr, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting ip data: %w", err)
+	}
+
+	if stderr != "" {
+		return nil, types.Result{}, fmt.Errorf("error while running command: %s", stderr)
 	}
 
 	// Strip empty lines from the output

--- a/pkg/kernel/mcp/iptables.go
+++ b/pkg/kernel/mcp/iptables.go
@@ -63,7 +63,7 @@ func (s *MCPServer) GetIptables(ctx context.Context, req *mcp.CallToolRequest, i
 	// Strip empty lines from the output
 	lines := utils.StripEmptyLines(strings.Split(stdout, "\n"))
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxOutputLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxOutputLines)
 	// Join the lines back into a single string
 	stdout = strings.Join(lines, "\n")
 	return nil, types.Result{Data: stdout}, nil

--- a/pkg/kernel/mcp/iptables.go
+++ b/pkg/kernel/mcp/iptables.go
@@ -51,9 +51,13 @@ func (s *MCPServer) GetIptables(ctx context.Context, req *mcp.CallToolRequest, i
 	// FilterParameters are invalid with -S/--list-rules command
 	cmd.AddIf(in.FilterParameters != "" && command != "-S" && command != "--list-rules", strings.Fields(in.FilterParameters)...)
 
-	stdout, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
+	stdout, stderr, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting list of iptables rules: %w", err)
+	}
+
+	if stderr != "" {
+		return nil, types.Result{}, fmt.Errorf("error while running command: %s", stderr)
 	}
 
 	// Strip empty lines from the output

--- a/pkg/kernel/mcp/mcp.go
+++ b/pkg/kernel/mcp/mcp.go
@@ -68,7 +68,7 @@ Example:
 
 Example output:
 tcp 6 91 ESTABLISHED src=1.2.3.4 dst=5.6.7.8 sport=32000 dport=10250 src=5.6.7.8 dst=1.2.3.4  sport=10250 dport=32000 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=2
-`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
+`, DefaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetConntrack)
 	// get-iptables tool registration
 	mcp.AddTool(server,
@@ -108,7 +108,7 @@ Example output:
 Chain POSTROUTING (policy ACCEPT 675K packets, 41M bytes)
  pkts bytes target     prot opt in     out     source               destination         
  675K   41M OVN-KUBE-EGRESS-IP-MULTI-NIC  all  --  *      *       0.0.0.0/0            0.0.0.0/0     							
-`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
+`, DefaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetIptables)
 	// get-nft tool registration
 	mcp.AddTool(server,
@@ -143,7 +143,7 @@ Example:
 - node='ovn-control-plane', command='list tables', address_families='inet'
 Example output:
 table inet ovn-kubernetes
-`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
+`, DefaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetNFT)
 	// get-ip tool registration
 	mcp.AddTool(server,
@@ -182,7 +182,7 @@ Example:
 - node='ovn-control-plane', options="-4", command='route show', filter_parameters='table all'
 Example output:
 default via 10.0.0.254 dev br-ex proto dhcp src 10.0.0.10 metric 48
-`, defaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
+`, DefaultMaxOutputLines, int(timeout.MaxTimeout.Seconds())),
 		}, s.GetIPCommandOutput)
 }
 

--- a/pkg/kernel/mcp/mcp.go
+++ b/pkg/kernel/mcp/mcp.go
@@ -187,22 +187,19 @@ default via 10.0.0.254 dev br-ex proto dhcp src 10.0.0.10 metric 48
 }
 
 // executeCommand executes a command on a node via kubectl debug
-func (s *MCPServer) executeCommand(ctx context.Context, namespace, node string, command []string) (string, error) {
+func (s *MCPServer) executeCommand(ctx context.Context, namespace, node string, command []string) (string, string, error) {
 	stdout, stderr, err := s.runDebugNodeCommand(ctx, namespace, node, s.cfg.Image, command, "", "", 0)
 	if err != nil {
-		return "", fmt.Errorf("error while establishing tty connection to the node: %w", err)
+		return "", "", fmt.Errorf("error while establishing tty connection to the node: %w", err)
 	}
 
 	// Filter out warning lines from stderr
 	if stderr != "" {
-		stderr := filterWarnings(stderr)
-		if stderr != "" {
-			return "", fmt.Errorf("error while running command: %s", stderr)
-		}
+		stderr = filterWarnings(stderr)
 	}
 
 	// Filter out warning lines from stdout
 	stdout = filterWarnings(stdout)
 
-	return stdout, nil
+	return stdout, stderr, nil
 }

--- a/pkg/kernel/mcp/nft.go
+++ b/pkg/kernel/mcp/nft.go
@@ -55,7 +55,7 @@ func (s *MCPServer) GetNFT(ctx context.Context, req *mcp.CallToolRequest, in typ
 	// Strip empty lines from the output
 	lines := utils.StripEmptyLines(strings.Split(stdout, "\n"))
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxOutputLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxOutputLines)
 	// Join the lines back into a single string
 	stdout = strings.Join(lines, "\n")
 	return nil, types.Result{Data: stdout}, nil

--- a/pkg/kernel/mcp/nft.go
+++ b/pkg/kernel/mcp/nft.go
@@ -43,9 +43,13 @@ func (s *MCPServer) GetNFT(ctx context.Context, req *mcp.CallToolRequest, in typ
 	cmd.Add(strings.Fields(command)...)
 	cmd.AddIf(addressFamilies != "", addressFamilies)
 
-	stdout, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
+	stdout, stderr, err := s.executeCommand(ctx, in.Namespace, in.Node, cmd.Build())
 	if err != nil {
 		return nil, types.Result{}, fmt.Errorf("error while getting nft data: %w", err)
+	}
+
+	if stderr != "" {
+		return nil, types.Result{}, fmt.Errorf("error while running command: %s", stderr)
 	}
 
 	// Strip empty lines from the output

--- a/pkg/kernel/mcp/util.go
+++ b/pkg/kernel/mcp/util.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	// defaultMaxOutputLines defines the maximum number of lines to return from command output
-	defaultMaxOutputLines = 100
+	// DefaultMaxOutputLines defines the maximum number of lines to return from command output
+	DefaultMaxOutputLines = 100
 )
 
 // ConntrackSummaryPattern matches conntrack informational stderr printed on successful -L/--dump.

--- a/pkg/kernel/mcp/util.go
+++ b/pkg/kernel/mcp/util.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/commandbuilder"
@@ -12,6 +13,10 @@ const (
 	// defaultMaxOutputLines defines the maximum number of lines to return from command output
 	defaultMaxOutputLines = 100
 )
+
+// ConntrackSummaryPattern matches conntrack informational stderr printed on successful -L/--dump.
+// Format: "conntrack v<version> (conntrack-tools): <count> flow entries have been shown."
+var ConntrackSummaryPattern = regexp.MustCompile(`^conntrack v\d+\.\d+\.\d+ \(conntrack-tools\): \d+ flow entries have been shown\.?$`)
 
 // utilityExists checks if a utility/command exists in the container
 func (s *MCPServer) utilityExists(ctx context.Context, namespace, node, utility string) error {
@@ -43,4 +48,27 @@ func filterWarnings(output string) string {
 	}
 
 	return strings.Join(filteredLines, "\n")
+}
+
+// splitConntrackSummary separates conntrack informational stderr from other stderr.
+// The conntrack informational stderr is printed when using conntrack CLI -L/--dump command.
+// Format: "conntrack v<version> (conntrack-tools): <count> flow entries have been shown."
+func splitConntrackSummary(output string) (summary, remaining string) {
+	if output == "" {
+		return "", ""
+	}
+
+	lines := strings.Split(output, "\n")
+	var summaryLines []string
+	var remainingLines []string
+
+	for _, line := range lines {
+		if ConntrackSummaryPattern.MatchString(line) {
+			summaryLines = append(summaryLines, line)
+		} else {
+			remainingLines = append(remainingLines, line)
+		}
+	}
+
+	return strings.Join(summaryLines, "\n"), strings.Join(remainingLines, "\n")
 }

--- a/pkg/kernel/mcp/util_test.go
+++ b/pkg/kernel/mcp/util_test.go
@@ -81,3 +81,61 @@ func TestFilterWarnings(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitConntrackSummary(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		expectedSummary   string
+		expectedRemaining string
+	}{
+		{
+			name:              "empty string",
+			input:             "",
+			expectedSummary:   "",
+			expectedRemaining: "",
+		},
+		{
+			name:              "conntrack dump summary",
+			input:             "conntrack v1.4.8 (conntrack-tools): 461 flow entries have been shown.",
+			expectedSummary:   "conntrack v1.4.8 (conntrack-tools): 461 flow entries have been shown.",
+			expectedRemaining: "",
+		},
+		{
+			name:              "conntrack dump summary with other stderr",
+			input:             "conntrack v1.4.9 (conntrack-tools): 52 flow entries have been shown.\nreal error message",
+			expectedSummary:   "conntrack v1.4.9 (conntrack-tools): 52 flow entries have been shown.",
+			expectedRemaining: "real error message",
+		},
+		{
+			name:              "unrelated stderr preserved",
+			input:             "command not found",
+			expectedSummary:   "",
+			expectedRemaining: "command not found",
+		},
+		{
+			name:              "partial match not treated as summary",
+			input:             "461 flow entries have been shown.",
+			expectedSummary:   "",
+			expectedRemaining: "461 flow entries have been shown.",
+		},
+		{
+			name:              "non conntrack-tools package not treated as summary",
+			input:             "conntrack v1.4.8 (other-tools): 10 flow entries have been shown.",
+			expectedSummary:   "",
+			expectedRemaining: "conntrack v1.4.8 (other-tools): 10 flow entries have been shown.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary, remaining := splitConntrackSummary(tt.input)
+			if summary != tt.expectedSummary {
+				t.Errorf("splitConntrackSummary() summary = %q, want %q", summary, tt.expectedSummary)
+			}
+			if remaining != tt.expectedRemaining {
+				t.Errorf("splitConntrackSummary() remaining = %q, want %q", remaining, tt.expectedRemaining)
+			}
+		})
+	}
+}

--- a/pkg/must-gather/mcp/mcp.go
+++ b/pkg/must-gather/mcp/mcp.go
@@ -102,7 +102,7 @@ Examples:
 - Get specific container logs: {"must_gather_path": "/path/to/must-gather", "namespace": "default", "name": "my-pod", "container": "my-container"}
 - Search for errors: {"must_gather_path": "/path/to/must-gather", "namespace": "default", "name": "my-pod", "pattern": "error|Error|ERROR"}
 - Get last 50 lines: {"must_gather_path": "/path/to/must-gather", "namespace": "default", "name": "my-pod", "tail": 50}
-- Get previous container logs: {"must_gather_path": "/path/to/must-gather", "namespace": "default", "name": "my-pod", "previous": true}`, defaultMaxLines, defaultMaxLines),
+- Get previous container logs: {"must_gather_path": "/path/to/must-gather", "namespace": "default", "name": "my-pod", "previous": true}`, DefaultMaxLines, DefaultMaxLines),
 	}, s.GetPodLogs)
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/pkg/must-gather/mcp/pods.go
+++ b/pkg/must-gather/mcp/pods.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
 )
 
-const defaultMaxLines = 100
+// DefaultMaxLines defines the maximum number of lines to return from command output
+const DefaultMaxLines = 100
 
 // GetPodLogs uses the omc command to get the logs of a pod. It will return an error if the
 // must gather path is not valid or the pod logs are not found.
@@ -35,7 +36,7 @@ func (s *MustGatherMCPServer) GetPodLogs(ctx context.Context, req *mcp.CallToolR
 	}
 
 	// Apply the head and tail parameters to the logs
-	lines = in.HeadTailParams.Apply(lines, defaultMaxLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxLines)
 
 	return nil, types.GetPodLogsResult{Logs: lines}, nil
 }

--- a/pkg/ovn/mcp/commands.go
+++ b/pkg/ovn/mcp/commands.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
 )
 
-const defaultMaxLines = 100
+// DefaultMaxLines defines the maximum number of lines to return from command output
+const DefaultMaxLines = 100
 
 // validateDatabase validates that the database is a valid OVN database.
 func validateDatabase(db ovntypes.Database) error {

--- a/pkg/ovn/mcp/mcp.go
+++ b/pkg/ovn/mcp/mcp.go
@@ -54,7 +54,7 @@ Example output for nbdb:
 {
   "database": "nbdb",
   "output": "switch 1234-5678 (node1)\n    port node1-k8s\n        addresses: [\"00:00:00:00:00:01\"]\n..."
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.Show)
 
 	mcp.AddTool(server,
@@ -106,7 +106,7 @@ Example getting specific columns:
   "table": "Logical_Switch",
   "columns": "name,ports",
   "output": "name: ovn-worker\nports: [uuid1, uuid2]\n\nname: join\nports: [uuid3]"
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.Get)
 
 	mcp.AddTool(server,
@@ -134,7 +134,7 @@ Example output:
     "table=0 (ls_in_port_sec_l2), priority=100, match=(inport == \"pod1\"), action=(next;)",
     "table=1 (ls_in_port_sec_ip), priority=90, match=(ip4), action=(next;)"
   ]
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.ListLogicalFlows)
 
 	mcp.AddTool(server,
@@ -169,7 +169,7 @@ Example output:
   "datapath": "node1",
   "microflow": "inport==\"pod1\" && ...",
   "output": "ingress(dp=\"node1\", inport=\"pod1\")\n  0. ls_in_port_sec_l2: inport == \"pod1\", priority 50, uuid 1234\n     next;\n..."
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.Trace)
 }
 
@@ -199,7 +199,7 @@ func (s *MCPServer) Show(ctx context.Context, req *mcp.CallToolRequest,
 	lines := utils.StripEmptyLines(strings.Split(stdout, "\n"))
 
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxLines)
 
 	// Join all lines into a single output string
 	result.Output = strings.Join(lines, "\n")
@@ -276,7 +276,7 @@ func (s *MCPServer) Get(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxLines)
 
 	result.Output = strings.Join(lines, "\n")
 	return nil, result, nil
@@ -322,7 +322,7 @@ func (s *MCPServer) ListLogicalFlows(ctx context.Context, req *mcp.CallToolReque
 	}
 
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxLines)
 
 	result.Flows = lines
 	return nil, result, nil
@@ -378,7 +378,7 @@ func (s *MCPServer) Trace(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxLines)
 
 	result.Output = strings.Join(lines, "\n")
 	return nil, result, nil

--- a/pkg/ovs/mcp/commands.go
+++ b/pkg/ovs/mcp/commands.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
 )
 
-const defaultMaxLines = 100
+// DefaultMaxLines defines the maximum number of lines to return from command output
+const DefaultMaxLines = 100
 
 var (
 	// validConntrackParam is the pattern for valid conntrack parameters.

--- a/pkg/ovs/mcp/mcp.go
+++ b/pkg/ovs/mcp/mcp.go
@@ -120,7 +120,7 @@ Parameters:
 Example output:
 {
   "output": "a1b2c3d4-5678-90ab-cdef-1234567890ab\n    Bridge br-int\n        Port ovn-k8s-mp0\n            Interface ovn-k8s-mp0\n                type: internal\n        Port br-int\n            Interface br-int\n                type: internal\n    ovs_version: \"2.17.0\""
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.Show)
 
 	mcp.AddTool(server,
@@ -146,7 +146,7 @@ Example output:
     "cookie=0x0, duration=123.456s, table=0, n_packets=100, n_bytes=10000, priority=100,in_port=1 actions=output:2",
     "cookie=0x0, duration=123.456s, table=0, n_packets=50, n_bytes=5000, priority=90,in_port=2 actions=output:1"
   ]
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.DumpFlows)
 
 	mcp.AddTool(server,
@@ -174,7 +174,7 @@ Example output:
     "tcp,orig=(src=10.244.0.5,dst=10.96.0.1,sport=45678,dport=443),reply=(src=10.96.0.1,dst=10.244.0.5,sport=443,dport=45678)",
     "udp,orig=(src=10.244.0.3,dst=8.8.8.8,sport=53214,dport=53),reply=(src=8.8.8.8,dst=10.244.0.3,sport=53,dport=53214)"
   ]
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.DumpConntrack)
 
 	mcp.AddTool(server,
@@ -208,7 +208,7 @@ Example output:
   "bridge": "br-int",
   "flow": "in_port=1,ip,nw_src=10.244.0.5,nw_dst=10.96.0.1",
   "output": "Flow: ip,in_port=1,nw_src=10.244.0.5,nw_dst=10.96.0.1\n\nbridge(\"br-int\")\n-------------\n 0. priority 100\n    resubmit(,10)\n10. ip,nw_dst=10.96.0.1, priority 200\n    load:0x1->NXM_NX_REG0[]\n    resubmit(,20)\n...\nFinal flow: ...\nDatapath actions: ..."
-}`, defaultMaxLines),
+}`, DefaultMaxLines),
 		}, s.DumpOfprotoTrace)
 }
 
@@ -251,7 +251,7 @@ func (s *MCPServer) Show(ctx context.Context, req *mcp.CallToolRequest,
 	lines := utils.StripEmptyLines(strings.Split(stdout, "\n"))
 
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxLines)
 
 	// Join all lines into a single output string
 	result.Output = strings.Join(lines, "\n")
@@ -343,7 +343,7 @@ func (s *MCPServer) DumpFlows(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	// Apply the head and tail parameters to the flows
-	flows = in.HeadTailParams.Apply(flows, defaultMaxLines)
+	flows = in.HeadTailParams.Apply(flows, DefaultMaxLines)
 
 	result.Flows = flows
 	return nil, result, nil
@@ -389,7 +389,7 @@ func (s *MCPServer) DumpConntrack(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	// Apply the head and tail parameters to the entries
-	entries = in.HeadTailParams.Apply(entries, defaultMaxLines)
+	entries = in.HeadTailParams.Apply(entries, DefaultMaxLines)
 
 	result.Entries = entries
 	return nil, result, nil
@@ -436,7 +436,7 @@ func (s *MCPServer) DumpOfprotoTrace(ctx context.Context, req *mcp.CallToolReque
 	}
 
 	// Apply the head and tail parameters to the lines
-	lines = in.HeadTailParams.Apply(lines, defaultMaxLines)
+	lines = in.HeadTailParams.Apply(lines, DefaultMaxLines)
 
 	// Join all lines into a single output string
 	result.Output = strings.Join(lines, "\n")

--- a/test/e2e/kernel_test.go
+++ b/test/e2e/kernel_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mcpKernel "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/mcp"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/kernel/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/test/e2e/utils"
 )
@@ -266,6 +267,46 @@ var _ = Describe("Kernel Tools", func() {
 	})
 
 	Context("get-conntrack", func() {
+		It("should retrieve connection tracking list from a node", func() {
+			By("Running get-conntrack to list connections")
+			output, err := mcpInspector.
+				MethodCall(getConntrackToolName, map[string]any{
+					"node":    nodeName,
+					"command": "-L",
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the result contains connection list")
+			result := utils.UnmarshalCallToolResult[types.Result](output)
+			Expect(result.Data).NotTo(BeEmpty())
+			// List output contains connection information from conntrack CLI or /proc/net/nf_conntrack.
+			// At least one marker must be present.
+			conntrackListMarkers := []string{
+				"src=", "dst=", "sport=", "dport=", "proto=", "state=",
+				"ESTABLISHED", "TIME_WAIT", "CLOSE",
+			}
+			Expect(result.Data).To(Satisfy(func(data string) bool {
+				for _, marker := range conntrackListMarkers {
+					if strings.Contains(data, marker) {
+						return true
+					}
+				}
+				return false
+			}))
+
+			// If the summary is present, check if it matches the expected format
+			// The summary format is as follows:
+			// -- conntrack summary --
+			// conntrack v<version> (conntrack-tools): <count> flow entries have been shown.
+			if strings.Contains(result.Data, "-- conntrack summary --") {
+				By("Checking the summary matches the expected format")
+				lines := strings.Split(strings.TrimSpace(result.Data), "\n")
+				summary := lines[len(lines)-1]
+				Expect(summary).To(MatchRegexp(mcpKernel.ConntrackSummaryPattern.String()))
+			}
+		})
+
 		It("should retrieve connection tracking count from a node", func() {
 			By("Running get-conntrack to count connections")
 			output, err := mcpInspector.


### PR DESCRIPTION
The conntrack -L/--dump CLI commands adds an informational message to stderr which was causing the tool to throw an error.
An example of such an informational message: `conntrack v1.4.8 (conntrack-tools): 461 flow entries have been shown.`

This PR now splits the informational message from the stderr and appends it to the final output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kernel networking command output (conntrack/iptables/nft/ip) now consistently applies exported default output truncation limits, and conntrack may include a dedicated summary section when available.
* **Bug Fixes**
  * Improved conntrack output handling to extract informational summary details and keep the main output clean.
  * Command execution is more robust: non-empty stderr is now treated as a failure after warning filtering.
* **Tests**
  * Added unit tests for conntrack summary extraction.
  * Extended end-to-end coverage for `get-conntrack -L`, including optional summary verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->