### PR TITLE
network-tools: De-duplicate similar parameters of tcpdump tool

### DIFF
--- a/pkg/network-tools/mcp/mcp.go
+++ b/pkg/network-tools/mcp/mcp.go
@@ -57,11 +57,9 @@ The image must contain the tcpdump utility
 
 Parameters:
 - target_type: 'node' or 'pod' (required)
-- node_name: Name of the node (required when target_type is 'node')
-- node_pod_namespace (optional): Namespace of the debug pod on which the command is expected to be executed when target_type is 'node'. Default: 'default'
-- pod_name: Name of the pod (required when target_type is 'pod')
-- pod_namespace: Namespace of the pod (required when target_type is 'pod')
-- container_name: Name of the container in the pod (optional, uses default container if not specified)
+- name: Name of the target (node or pod) (required)
+- namespace: Namespace of the target (node or pod). Required when target_type is 'pod'. Optional when target_type is 'node' and defaults to 'default'.
+- container_name: Name of the container in the pod when target_type is 'pod' (optional, uses default container if not specified)
 - interface: Network interface name or 'any' (optional, uses default if not specified)
 - packet_count: Number of packets to capture (default: 100, max: 1000)
 - bpf_filter: BPF filter expression to match packets (optional, e.g., "tcp and dst port 8080", "host 10.0.0.1")
@@ -69,9 +67,9 @@ Parameters:
 - timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 
 Examples:
-- Capture on node: {"target_type": "node", "node_name": "worker-1", "interface": "eth0", "packet_count": 100, "bpf_filter": "tcp port 80"}
-- Capture in pod: {"target_type": "pod", "pod_name": "my-pod", "pod_namespace": "default", "interface": "eth0", "packet_count": 100, "bpf_filter": "host 10.0.0.1"}
-- Capture DNS: {"target_type": "node", "node_name": "worker-1", "interface": "any", "packet_count": 50, "bpf_filter": "port 53"}`,
+- Capture on node: {"target_type": "node", "name": "worker-1", "interface": "eth0", "packet_count": 100, "bpf_filter": "tcp port 80"}
+- Capture in pod: {"target_type": "pod", "name": "my-pod", "namespace": "default", "interface": "eth0", "packet_count": 100, "bpf_filter": "host 10.0.0.1"}
+- Capture DNS: {"target_type": "node", "name": "worker-1", "interface": "any", "packet_count": 50, "bpf_filter": "port 53"}`,
 				int(timeout.MaxTimeout.Seconds())),
 		}, s.Tcpdump)
 	mcp.AddTool(server,

--- a/pkg/network-tools/mcp/tcpdump.go
+++ b/pkg/network-tools/mcp/tcpdump.go
@@ -23,6 +23,15 @@ const (
 
 // Tcpdump executes the tcpdump packet capture tool on a node or inside a pod.
 func (s *MCPServer) Tcpdump(ctx context.Context, req *mcp.CallToolRequest, in types.TcpdumpParams) (*mcp.CallToolResult, types.CommandResult, error) {
+	if in.TargetType == "" || (in.TargetType != "node" && in.TargetType != "pod") {
+		return nil, types.CommandResult{}, fmt.Errorf("target_type is required and must be 'node' or 'pod'")
+	}
+	if in.Name == "" {
+		return nil, types.CommandResult{}, fmt.Errorf("name is required when target_type is '%s'", in.TargetType)
+	}
+	if in.TargetType == "pod" && in.Namespace == "" {
+		return nil, types.CommandResult{}, fmt.Errorf("namespace is required when target_type is 'pod'")
+	}
 	if err := validateInterface(in.Interface); err != nil {
 		return nil, types.CommandResult{}, err
 	}
@@ -61,13 +70,13 @@ func (s *MCPServer) Tcpdump(ctx context.Context, req *mcp.CallToolRequest, in ty
 
 	switch in.TargetType {
 	case "node":
-		stdout, stderr, err := s.runDebugNodeCommand(ctx, in.NodePodNamespace, in.NodeName, s.cfg.TcpdumpImage, cmd.Build(), "", "", 0)
+		stdout, stderr, err := s.runDebugNodeCommand(ctx, in.Namespace, in.Name, s.cfg.TcpdumpImage, cmd.Build(), "", "", 0)
 		if err != nil {
 			return nil, types.CommandResult{}, err
 		}
 		return nil, types.CommandResult{Output: stdout, Stderr: stderr}, nil
 	case "pod":
-		stdout, stderr, err := s.runPodExecCommand(ctx, in.PodNamespace, in.PodName, in.ContainerName, cmd.Build())
+		stdout, stderr, err := s.runPodExecCommand(ctx, in.Namespace, in.Name, in.ContainerName, cmd.Build())
 		if err != nil {
 			return nil, types.CommandResult{}, err
 		}

--- a/pkg/network-tools/types/manifest.go
+++ b/pkg/network-tools/types/manifest.go
@@ -14,13 +14,11 @@ type TcpdumpParams struct {
 
 	TargetType string `json:"target_type"`
 
-	// Node-specific fields
-	NodeName         string `json:"node_name,omitempty"`
-	NodePodNamespace string `json:"node_pod_namespace,omitempty"`
+	// Combined node and pod fields
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
 
-	// Pod-specific fields
-	PodName       string `json:"pod_name,omitempty"`
-	PodNamespace  string `json:"pod_namespace,omitempty"`
+	// Pod-specific field
 	ContainerName string `json:"container_name,omitempty"`
 
 	Interface   string `json:"interface,omitempty"`


### PR DESCRIPTION
This PR de-duplicates similar parameters of tcpdump tool.

Following are the changes:
- `node_name` and `pod_name` fields are consolidated into `name` field.
- `node_pod_namespace` and `pod_namespace` are consolidated into `namespace` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Unified tcpdump target selection to use `name` with optional `namespace` (supports both node and pod captures).

* **Bug Fixes**
  * Improved request validation: rejects tcpdump requests missing `name`, and for pod captures also requires `namespace`.

* **Documentation**
  * Refreshed tcpdump tool parameter descriptions and example JSON to use the new `name`/`namespace` fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->