### PR TITLE
docs: add user guide covering all MCP tool categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Repo hosting the Model Context Protocol Server for troubleshooting OVN-Kubernete
 - [Tools available in MCP Server](#tools-available-in-mcp-server)
   - [Live Cluster Mode](#live-cluster-mode-1)
   - [Offline Mode](#offline-mode-1)
+- [User Guide](docs/user-guide.md) — full parameter reference and examples for every tool
 
 ---
 
@@ -293,6 +294,8 @@ args:
 ```
 
 ---
+
+Full parameter reference: [User Guide](docs/user-guide.md).
 
 <!-- TOOLS_SECTION_START -->
 ## Tools available in MCP Server

--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -193,7 +193,6 @@ func parseFlags() *MCPServerConfig {
 	flag.StringVar(&cfg.Port, "port", "8080", "Port to use")
 	flag.StringVar(&cfg.Kubernetes.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 	flag.StringVar(&cfg.NetworkTools.PwruImage, "pwru-image", "docker.io/cilium/pwru:v1.0.10", "Container image for pwru operations")
-
 	flag.StringVar(&cfg.NetworkTools.TcpdumpImage, "tcpdump-image", defaultNetshootImage, "Container image for tcpdump operations")
 	flag.StringVar(&cfg.Kernel.Image, "kernel-image", defaultNetshootImage, "Container image for kernel operations")
 	flag.IntVar(&timeoutSeconds, "tool-timeout", 120, "Timeout in seconds for tool operations (0 to disable)")

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -1,0 +1,142 @@
+# Kernel tools
+
+Live-cluster tools that run on a Kubernetes node via an ephemeral debug pod. Available with `--mode live-cluster` or `--mode dual`.
+
+See also: [User guide](user-guide.md) (including [common parameters](user-guide.md#common-parameters))
+
+The debug pod uses the image from `--kernel-image` (default `nicolaka/netshoot:v0.15`) and mounts the host filesystem.
+
+| Tool | Description |
+|------|-------------|
+| [`get-conntrack`](#get-conntrack) | Interact with the connection tracking system of a Kubernetes node |
+| [`get-iptables`](#get-iptables) | List packet filter rules (iptables / ip6tables) |
+| [`get-nft`](#get-nft) | List packet filtering and classification rules (nftables) |
+| [`get-ip`](#get-ip) | List routing, network devices, and interfaces (`ip`) |
+
+---
+
+## get-conntrack
+
+Use this command to discover a list of all (or a filtered selection of) currently tracked connections.
+
+The tool prefers the `conntrack` CLI in the configured `--kernel-image`. If that binary is missing, it falls back to reading `/proc/net/nf_conntrack`, which only supports dump/list (`-L`/`--dump`) with limited filtering. Count (`-C`/`--count`) and stats (`-S`/`--stats`) require the `conntrack` CLI.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `node` | string | **yes** | — | Name of the node from where conntrack entries are expected to be extracted |
+| `namespace` | string | no | `"default"` | Namespace of the debug pod from where conntrack entries are expected to be extracted |
+| `command` | string | no | `"-L"` | These options specify the particular operation to perform. These options can only be used if configured image has `conntrack` utility available. If omitted or empty, defaults to `-L`. `-L`/`--dump`: List connection tracking table. `-C`/`--count`: Show the table counter. `-S`/`--stats`: Show the in-kernel connection tracking system statistics |
+| `filter_parameters` | string | no | — | These parameters are useful to filter certain entries from the whole table: `-s`/`--src`/`--orig-src IP_ADDRESS`: Match only entries whose source address in the original direction equals to mentioned IP. `-d`/`--dst`/`--orig-dst IP_ADDRESS`: Match only entries whose destination address in the original direction equals to mentioned IP. `-p`/`--proto PROTO`: Specify layer four (TCP, UDP, ...) protocol. `--sport`/`--orig-port-src PORT`: Source port in original direction. `--dport`/`--orig-port-dst PORT`: Destination port in original direction |
+
+Also accepts common [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting) and [`timeout_seconds`](user-guide.md#per-call-timeout).
+
+### Examples
+
+```json
+{"node": "ovn-control-plane", "command": "-L"}
+```
+
+```json
+{"node": "ovn-worker", "namespace": "ovn-kubernetes", "command": "-L"}
+```
+
+```json
+{
+  "node": "ovn-worker",
+  "filter_parameters": "-s 1.2.3.4 -d 5.6.7.8 -p tcp --sport 32000 --dport 10250"
+}
+```
+
+---
+
+## get-iptables
+
+Iptables and ip6tables are used to inspect the tables of IPv4 and IPv6 packet filter rules in the Linux kernel.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `node` | string | **yes** | — | Name of the node from where packet filter rules are expected to be extracted |
+| `namespace` | string | no | `"default"` | Namespace of the debug pod from where packet filter rules are expected to be extracted |
+| `table` | string | no | `"filter"` | There are currently five independent tables (which tables are present at any time depends on the kernel configuration options and which modules are present). `filter`: This is the default table. `nat`: This table is consulted when a packet that creates a new connection is encountered. `mangle`: This table is used for specialized packet alteration. `raw`: This table is used mainly for configuring exemptions from connection tracking in combination with the NOTRACK target. `security`: This table is used for Mandatory Access Control (MAC) networking rules |
+| `command` | string | no | `"-L"` | These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below. If omitted or empty, defaults to `-L`. `-L`/`--list [chain]`: List all rules in the selected chain. If no chain is selected, all chains are listed. `-S`/`--list-rules [chain]`: Print all rules in the selected chain. If no chain is selected, all chains are printed like iptables-save |
+| `filter_parameters` | string | no | — | These parameters are useful to filter certain entries from the whole table: `-s`/`--source address[/mask]`: Source specification. Address can be either a network name, a hostname, a network IP address (with /mask), or a plain IP address. `-d`/`--destination address[/mask]`: Destination specification. `-v`/`--verbose`: Verbose output. `-n`/`--numeric`: Numeric output. IP addresses and port numbers will be printed in numeric format. `-p`/`--protocol protocol`: The protocol of the rule or of the packet to check. `-4`/`--ipv4`: IPv4. `-6`/`--ipv6`: IPv6 |
+
+Also accepts common [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting) and [`timeout_seconds`](user-guide.md#per-call-timeout).
+
+### Examples
+
+```json
+{
+  "node": "ovn-control-plane",
+  "table": "nat",
+  "filter_parameters": "-nv4"
+}
+```
+
+```json
+{
+  "node": "ovn-control-plane",
+  "table": "nat",
+  "command": "-L"
+}
+```
+
+---
+
+## get-nft
+
+Lists packet filtering and classification rules via `nft`.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `node` | string | **yes** | — | Name of the node from where packet filtering and classification rules are expected to be extracted |
+| `namespace` | string | no | `"default"` | Namespace of the debug pod from where packet filtering and classification rules are expected to be extracted |
+| `command` | string | **yes** | — | These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below. `list ruleset`: The ruleset keyword is used to identify the whole set of tables, chains, etc. Print the ruleset in human-readable format. `list tables`: List all chains and rules of the specified table. `list chains`: List all rules of the specified chain. `list sets`: Display the elements in the specified set. `list maps`: Display the elements in the specified map. `list flowtables`: List all flowtables |
+| `address_families` | string | no | — | Address families determine the type of packets which are processed. For each address family, the kernel contains so-called hooks at specific stages of the packet processing paths, which invoke nftables if rules for these hooks exist. `ip`: IPv4 address family. `ip6`: IPv6 address family. `inet`: Internet (IPv4/IPv6) address family. `arp`: ARP address family, handling IPv4 ARP packets. `bridge`: Bridge address family, handling packets which traverse a bridge device. `netdev`: Netdev address family, handling packets on ingress and egress |
+
+Also accepts common [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting) and [`timeout_seconds`](user-guide.md#per-call-timeout).
+
+### Examples
+
+```json
+{
+  "node": "ovn-control-plane",
+  "command": "list tables",
+  "address_families": "inet"
+}
+```
+
+---
+
+## get-ip
+
+Lists routing, network devices, and interfaces via `ip`.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `node` | string | **yes** | — | Name of the node on which ip command is expected to be executed |
+| `namespace` | string | no | `"default"` | Namespace of the debug pod on which ip command is expected to be executed |
+| `options` | string | no | — | These options helps in providing more details or formatting output data. `-d`/`-details`: Output more detailed information. `-4`: shortcut for `-family inet`. `-6`: shortcut for `-family inet6`. `-r`/`-resolve`: use the system's name resolver to print DNS names instead of host addresses. `-n`/`-netns <NETNS>`: switches ip to the specified network namespace NETNS. `-a`/`-all`: executes specified command over all objects, it depends if command supports this option |
+| `command` | string | **yes** | — | These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below. `address show`: protocol (IP or IPv6) address on a device. `link show`: network device. `neighbour show`: manage ARP or NDISC cache entries. `netns show`: manage network namespaces. `route show`: routing table entry. `rule show`: rule in routing policy database. `vrf show`: manage virtual routing and forwarding devices. `xfrm state list`: show Security Association Database. `xfrm policy list`: show Security Policy Database |
+| `filter_parameters` | string | no | — | This allows to mention sub command to get more filtered data. Available sub command varies and supportability depends on what is already supported with `ip` utility |
+
+Also accepts common [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting) and [`timeout_seconds`](user-guide.md#per-call-timeout).
+
+### Examples
+
+```json
+{
+  "node": "ovn-control-plane",
+  "options": "-4",
+  "command": "route show",
+  "filter_parameters": "table all"
+}
+```

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,196 @@
+# Kubernetes tools
+
+Live-cluster tools for inspecting pods and Kubernetes API resources. Available with `--mode live-cluster` or `--mode dual`.
+
+See also: [User guide](user-guide.md) (including [common parameters](user-guide.md#common-parameters))
+
+| Tool | Description |
+|------|-------------|
+| [`pod-logs`](#pod-logs) | Get container logs from a pod in the Kubernetes cluster |
+| [`resource-get`](#resource-get) | Get a specific Kubernetes resource by name |
+| [`resource-list`](#resource-list) | List Kubernetes resources of a specific kind |
+
+---
+
+## pod-logs
+
+Retrieves logs from a running or terminated pod. Supports filtering by pattern, limiting output with head/tail, and retrieving logs from previous container instances.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | **yes** | — | Name of the pod |
+| `namespace` | string | no | `"default"` | Namespace of the pod |
+| `container` | string | no | — | Specific container name (required for multi-container pods) |
+| `previous` | boolean | no | `false` | If true, get logs from previous container instance (useful for crash analysis) |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{"name": "my-pod", "namespace": "default"}
+```
+
+```json
+{"name": "my-pod", "namespace": "default", "container": "my-container"}
+```
+
+```json
+{"name": "my-pod", "namespace": "default", "previous": true}
+```
+
+```json
+{"name": "my-pod", "namespace": "default", "pattern": "error|Error|ERROR"}
+```
+
+```json
+{"name": "my-pod", "namespace": "default", "tail": 50}
+```
+
+```json
+{
+  "name": "my-pod",
+  "namespace": "default",
+  "head": 50,
+  "tail": 100,
+  "apply_tail_first": true
+}
+```
+
+---
+
+## resource-get
+
+Retrieves a single resource from the cluster using its group, version, kind, and name. Supports different output formats for viewing the resource data.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `group` | string | no | empty (core resources) | API group of the resource (e.g., `"apps"`, `"networking.k8s.io"`). Empty for core resources |
+| `version` | string | **yes** | — | API version of the resource (e.g., `"v1"`, `"v1beta1"`) |
+| `kind` | string | **yes** | — | Kind of the resource (e.g., `"Pod"`, `"Service"`, `"Deployment"`, `"ConfigMap"`) |
+| `name` | string | **yes** | — | Name of the resource to retrieve |
+| `namespace` | string | no | `"default"` for namespaced resources; empty for cluster-scoped | Namespace of the resource. If omitted, defaults to `"default"` for namespaced resources and empty for cluster-scoped resources |
+| `output_type` | string | no | table format with name, namespace, age | Output format - `"yaml"`, `"json"`, `"jsonpath"`, or `"wide"` (wide will include labels and annotations) |
+
+### Examples
+
+```json
+{"version": "v1", "kind": "Pod", "name": "my-pod"}
+```
+
+```json
+{
+  "group": "apps",
+  "version": "v1",
+  "kind": "Deployment",
+  "name": "my-deployment",
+  "namespace": "default",
+  "output_type": "yaml"
+}
+```
+
+```json
+{"version": "v1", "kind": "Node", "name": "worker-0"}
+```
+
+```json
+{
+  "version": "v1",
+  "kind": "ConfigMap",
+  "name": "my-config",
+  "namespace": "kube-system",
+  "output_type": "json"
+}
+```
+
+```json
+{
+  "version": "v1",
+  "kind": "Pod",
+  "name": "my-pod",
+  "namespace": "default",
+  "output_type": "jsonpath='{.metadata.name}'"
+}
+```
+
+```json
+{
+  "version": "v1",
+  "kind": "Pod",
+  "name": "my-pod",
+  "namespace": "default",
+  "output_type": "wide"
+}
+```
+
+---
+
+## resource-list
+
+Lists resources in a namespace or across all namespaces. Supports filtering by label selector and different output formats.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `group` | string | no | empty (core resources) | API group of the resource (e.g., `"apps"`, `"networking.k8s.io"`). Empty for core resources |
+| `version` | string | **yes** | — | API version of the resource (e.g., `"v1"`, `"v1beta1"`) |
+| `kind` | string | **yes** | — | Kind of the resource (e.g., `"Pod"`, `"Service"`, `"Deployment"`) |
+| `namespace` | string | no | all namespaces | Filter by namespace. If omitted, lists resources across all namespaces |
+| `label_selector` | string | no | — | Filter by label selector (e.g., `"app=my-app"`, `"component=network"`) |
+| `output_type` | string | no | table format with name, namespace, age | Output format - `"yaml"`, `"json"`, `"jsonpath"`, or `"wide"` (wide will include labels and annotations) |
+
+### Examples
+
+```json
+{"version": "v1", "kind": "Pod", "namespace": "default"}
+```
+
+```json
+{"version": "v1", "kind": "Service"}
+```
+
+```json
+{
+  "version": "v1",
+  "kind": "Pod",
+  "namespace": "default",
+  "label_selector": "app=my-app"
+}
+```
+
+```json
+{
+  "group": "apps",
+  "version": "v1",
+  "kind": "Deployment",
+  "namespace": "default",
+  "output_type": "yaml"
+}
+```
+
+```json
+{"version": "v1", "kind": "Node"}
+```
+
+```json
+{
+  "version": "v1",
+  "kind": "Pod",
+  "namespace": "kube-system",
+  "output_type": "wide"
+}
+```
+
+```json
+{
+  "version": "v1",
+  "kind": "Pod",
+  "namespace": "default",
+  "output_type": "jsonpath='{.items[*].metadata.name}'"
+}
+```

--- a/docs/must-gather.md
+++ b/docs/must-gather.md
@@ -1,0 +1,318 @@
+# Must-gather tools
+
+Offline tools for querying must-gather archives via [`omc`](https://github.com/gmeghnag/omc). Available with `--mode offline` or `--mode dual`.
+
+See also: [User guide](user-guide.md) (including [which tools share common parameters](user-guide.md#common-parameters))
+
+## Prerequisites
+
+| Requirement | Applies to |
+|-------------|------------|
+| `omc` on `PATH` | All must-gather tools |
+| `ovsdb-tool` on `PATH` | Database list and query tools only — those tools are **not registered** if the binary is missing |
+
+| Tool | Description |
+|------|-------------|
+| [`must-gather-get-resource`](#must-gather-get-resource) | Get a specific Kubernetes resource from a must-gather archive |
+| [`must-gather-list-resources`](#must-gather-list-resources) | List Kubernetes resources of a specific kind from a must-gather archive |
+| [`must-gather-pod-logs`](#must-gather-pod-logs) | Get container logs from a pod in a must-gather archive |
+| [`must-gather-ovnk-info`](#must-gather-ovnk-info) | Get OVN-Kubernetes networking information from a must-gather archive |
+| [`must-gather-list-northbound-databases`](#must-gather-list-northbound-databases) | List OVN Northbound database files available in a must-gather archive *(needs ovsdb-tool)* |
+| [`must-gather-list-southbound-databases`](#must-gather-list-southbound-databases) | List OVN Southbound database files available in a must-gather archive *(needs ovsdb-tool)* |
+| [`must-gather-query-database`](#must-gather-query-database) | Query an OVN database from a must-gather archive using ovsdb-tool *(needs ovsdb-tool)* |
+
+---
+
+## must-gather-get-resource
+
+Returns the resource definition in the requested format. Use this to inspect specific resource configurations, status, and metadata from the must-gather snapshot.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `must_gather_path` | string | **yes** | — | Absolute path to extracted must-gather directory |
+| `kind` | string | **yes** | — | Kubernetes resource kind (e.g., Pod, Service, Node, Deployment, ConfigMap) |
+| `name` | string | **yes** | — | Name of the resource to retrieve |
+| `namespace` | string | no | `"default"` for namespaced resources | Namespace of the resource |
+| `output_type` | string | no | table format | Output format - `"yaml"`, `"json"`, `"wide"`, or `"jsonpath"` |
+
+### Examples
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "Pod",
+  "namespace": "default",
+  "name": "my-pod"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "Node",
+  "name": "worker-0",
+  "output_type": "yaml"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "ConfigMap",
+  "namespace": "kube-system",
+  "name": "my-config"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "Pod",
+  "namespace": "default",
+  "name": "my-pod",
+  "output_type": "jsonpath='{.metadata.name}'"
+}
+```
+
+---
+
+## must-gather-list-resources
+
+Returns a list of matching resources. Use this to discover what resources exist in the must-gather snapshot before retrieving specific ones with `must-gather-get-resource`.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `must_gather_path` | string | **yes** | — | Absolute path to extracted must-gather directory |
+| `kind` | string | **yes** | — | Kubernetes resource kind (e.g., Pod, Service, Node, Deployment) |
+| `namespace` | string | no | all namespaces | Filter by namespace. If omitted, lists resources across all namespaces |
+| `label_selector` | string | no | — | Filter by label selector (e.g., `"app=ovnkube-node"`, `"component=network"`) |
+| `output_type` | string | no | table format | Output format - `"yaml"`, `"json"`, `"wide"`, or `"jsonpath"` |
+
+### Examples
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "Pod",
+  "namespace": "default"
+}
+```
+
+```json
+{"must_gather_path": "/path/to/must-gather", "kind": "Node"}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "Pod",
+  "label_selector": "app=my-app"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "Service",
+  "namespace": "kube-system",
+  "output_type": "json"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "kind": "Pod",
+  "namespace": "default",
+  "output_type": "jsonpath='{.items[*].metadata.name}'"
+}
+```
+
+---
+
+## must-gather-pod-logs
+
+Returns log lines as an array. If neither head nor tail is specified, returns the first 100 lines by default. Use pattern matching to search for specific errors, warnings, or events in the logs.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `must_gather_path` | string | **yes** | — | Absolute path to extracted must-gather directory |
+| `name` | string | **yes** | — | Name of the pod |
+| `namespace` | string | no | `"default"` namespace | Namespace of the pod |
+| `container` | string | no | — | Specific container name (required for multi-container pods) |
+| `previous` | boolean | no | `false` | If true, get logs from previous container instance (useful for crash analysis) |
+| `rotated` | boolean | no | `false` | If true, include rotated log files |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "namespace": "default",
+  "name": "my-pod"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "namespace": "default",
+  "name": "my-pod",
+  "container": "my-container"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "namespace": "default",
+  "name": "my-pod",
+  "pattern": "error|Error|ERROR"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "namespace": "default",
+  "name": "my-pod",
+  "tail": 50
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "namespace": "default",
+  "name": "my-pod",
+  "previous": true
+}
+```
+
+---
+
+## must-gather-ovnk-info
+
+Use this to retrieve high-level OVN-Kubernetes networking information that helps diagnose network configuration and connectivity issues.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `must_gather_path` | string | **yes** | — | Absolute path to extracted must-gather directory |
+| `info_type` | string | **yes** | — | Type of OVN-K info to retrieve. Valid values: `"extrainfo"`: Get extra OVN-Kubernetes debugging information. `"hostnetinfo"`: Get host networking configuration and status. `"subnets"`: Get OVN subnet allocations and network topology |
+
+### Examples
+
+```json
+{"must_gather_path": "/path/to/must-gather", "info_type": "subnets"}
+```
+
+```json
+{"must_gather_path": "/path/to/must-gather", "info_type": "hostnetinfo"}
+```
+
+```json
+{"must_gather_path": "/path/to/must-gather", "info_type": "extrainfo"}
+```
+
+---
+
+## must-gather-list-northbound-databases
+
+Returns a mapping of database files to their source nodes. The Northbound database (nbdb) contains the logical network configuration: logical switches, routers, ports, ACLs, and load balancers.
+
+Use this to discover available database files before querying with `must-gather-query-database`. Each OVN controller node may have its own database snapshot.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `must_gather_path` | string | **yes** | — | Absolute path to extracted must-gather directory |
+
+### Examples
+
+```json
+{"must_gather_path": "/path/to/must-gather"}
+```
+
+---
+
+## must-gather-list-southbound-databases
+
+Returns a mapping of database files to their source nodes. The Southbound database (sbdb) contains the physical network bindings: chassis info, port bindings, MAC bindings, and datapath flows.
+
+Use this to discover available database files before querying with `must-gather-query-database`. Each OVN controller node may have its own database snapshot.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `must_gather_path` | string | **yes** | — | Absolute path to extracted must-gather directory |
+
+### Examples
+
+```json
+{"must_gather_path": "/path/to/must-gather"}
+```
+
+---
+
+## must-gather-query-database
+
+Returns query results in JSON format. Use this to inspect OVN database state for debugging network connectivity, policy enforcement, and load balancing issues.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `must_gather_path` | string | **yes** | — | Absolute path to extracted must-gather directory |
+| `database_name` | string | **yes** | — | Database file name from `must-gather-list-northbound-databases` or `must-gather-list-southbound-databases`. Must end with `"_nbdb"` or `"_sbdb"` |
+| `table` | string | **yes** | — | OVN database table to query. Common tables: Northbound: `Logical_Switch`, `Logical_Router`, `Logical_Switch_Port`, `ACL`, `Load_Balancer`, `NAT`. Southbound: `Chassis`, `Port_Binding`, `MAC_Binding`, `Datapath_Binding`, `SB_Global` |
+| `conditions` | string[] | no | returns all rows | Array of condition strings in OVSDB format: `["column","op","value"]`. Example: `["[\"hostname\",\"==\",\"worker-0\"]"]` |
+| `columns` | string[] | no | returns all columns | Array of column names to return |
+
+### Examples
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "database_name": "ovnkube-node-abc123_sbdb",
+  "table": "Chassis"
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "database_name": "ovnkube-node-abc123_sbdb",
+  "table": "Chassis",
+  "conditions": ["[\"hostname\",\"==\",\"worker-0\"]"]
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "database_name": "ovnkube-node-abc123_nbdb",
+  "table": "Logical_Switch",
+  "columns": ["name", "ports"]
+}
+```
+
+```json
+{
+  "must_gather_path": "/path/to/must-gather",
+  "database_name": "ovnkube-node-abc123_sbdb",
+  "table": "Port_Binding",
+  "columns": ["logical_port", "chassis", "type"]
+}
+```

--- a/docs/network-tools.md
+++ b/docs/network-tools.md
@@ -1,0 +1,118 @@
+# Network tools
+
+Live-cluster packet capture and kernel stack tracing. Available with `--mode live-cluster` or `--mode dual`.
+
+See also: [User guide](user-guide.md) (including [common parameters](user-guide.md#common-parameters))
+
+| Tool | Description |
+|------|-------------|
+| [`tcpdump`](#tcpdump) | Capture network packets on a node or inside a pod |
+| [`pwru`](#pwru) | Trace packets through the Linux kernel networking stack using eBPF |
+
+---
+
+## tcpdump
+
+Captures packets with BPF filtering under fixed caps so runs stay bounded.
+
+Safety / targeting limits:
+
+- Max packets: `packet_count` default **100**, hard max **1000**
+- Max snaplen: default **96** bytes, hard max **1500** bytes
+- Timeout: common [`timeout_seconds`](user-guide.md#per-call-timeout) (server default **120s**, per-call max **300s**)
+- Target rules: `target_type` must be `node` or `pod`; `name` is required; `namespace` is required for `pod` (defaults to `default` for the node debug pod); `container_name` is optional for `pod`
+
+Node captures run in a debug pod on the named node; pod captures exec into the existing pod.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `target_type` | string | **yes** | — | `"node"` or `"pod"` |
+| `name` | string | **yes** | — | Name of the target (node or pod) |
+| `namespace` | string | required when `target_type` is `"pod"`; optional when `target_type` is `"node"` | `"default"` when `target_type` is `"node"` | Namespace of the target (node or pod) |
+| `container_name` | string | no | — (default container) | Name of the container in the pod when `target_type` is `"pod"` |
+| `interface` | string | no | — (tool default) | Network interface name or `"any"` |
+| `packet_count` | integer | no | `100` (max: `1000`) | Number of packets to capture |
+| `bpf_filter` | string | no | — | BPF filter expression to match packets (e.g., `"tcp and dst port 8080"`, `"host 10.0.0.1"`) |
+| `snaplen` | integer | no | `96` (max: `1500`) | Snapshot length in bytes |
+
+Also accepts common [`timeout_seconds`](user-guide.md#per-call-timeout).
+
+### Examples
+
+```json
+{
+  "target_type": "node",
+  "name": "worker-1",
+  "interface": "eth0",
+  "packet_count": 100,
+  "bpf_filter": "tcp port 80"
+}
+```
+
+```json
+{
+  "target_type": "pod",
+  "name": "my-pod",
+  "namespace": "default",
+  "interface": "eth0",
+  "packet_count": 100,
+  "bpf_filter": "host 10.0.0.1"
+}
+```
+
+```json
+{
+  "target_type": "node",
+  "name": "worker-1",
+  "interface": "any",
+  "packet_count": 50,
+  "bpf_filter": "port 53"
+}
+```
+
+---
+
+## pwru
+
+pwru (packet, where are you?) shows which kernel functions process a packet, helping debug packet drops, routing issues, and understanding the kernel's packet processing path.
+
+This tool creates a specialized debug pod on the specified node with necessary eBPF capabilities to trace packets through kernel networking functions.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `node_name` | string | **yes** | — | Name of the node to run pwru on |
+| `node_pod_namespace` | string | no | `"default"` | Namespace of the debug pod on which the command is expected to be executed |
+| `bpf_filter` | string | no | — | BPF filter expression to match packets (e.g., `"tcp and dst port 8080"`, `"host 10.0.0.1"`) |
+| `output_limit_lines` | integer | no | `100` (max: `1000`) | Maximum number of trace events to capture |
+
+Also accepts common [`timeout_seconds`](user-guide.md#per-call-timeout).
+
+### Examples
+
+```json
+{
+  "node_name": "worker-1",
+  "bpf_filter": "host 10.244.0.5",
+  "output_limit_lines": 100
+}
+```
+
+```json
+{
+  "node_name": "worker-1",
+  "bpf_filter": "tcp and dst port 8080",
+  "output_limit_lines": 50
+}
+```
+
+```json
+{
+  "node_name": "worker-1",
+  "bpf_filter": "icmp",
+  "output_limit_lines": 100
+}
+```

--- a/docs/ovn.md
+++ b/docs/ovn.md
@@ -1,0 +1,180 @@
+# OVN tools
+
+Live-cluster tools that exec into an OVN / ovnkube pod and query the OVN Northbound or Southbound databases. Available with `--mode live-cluster` or `--mode dual`.
+
+See also: [User guide](user-guide.md) (including [common parameters](user-guide.md#common-parameters))
+
+| Tool | Description |
+|------|-------------|
+| [`ovn-show`](#ovn-show) | Display a comprehensive overview of OVN configuration from either the Northbound or Southbound database |
+| [`ovn-get`](#ovn-get) | Query records from an OVN database table with flexible filtering |
+| [`ovn-lflow-list`](#ovn-lflow-list) | List logical flows from the OVN Southbound database |
+| [`ovn-trace`](#ovn-trace) | Trace a packet through the OVN logical network |
+
+---
+
+## ovn-show
+
+For Northbound (`nbdb`): Runs `ovn-nbctl show` and displays logical switches, logical routers, their ports, and connections between them.
+
+For Southbound (`sbdb`): Runs `ovn-sbctl show` and displays chassis information, port bindings, and their relationships.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | no | — | Kubernetes namespace of the OVN pod (e.g., `"ovn-kubernetes"`) |
+| `name` | string | **yes** | — | Name of the pod running OVN (e.g., `"ovnkube-node-xxxxx"`) |
+| `database` | string | **yes** | — | OVN database to query - `"nbdb"` for Northbound or `"sbdb"` for Southbound |
+
+Also accepts common [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "database": "nbdb"
+}
+```
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "database": "sbdb",
+  "tail": 50
+}
+```
+
+---
+
+## ovn-get
+
+This is a versatile command that can:
+
+1. List all records in a table (when no record specified)
+2. Get a specific record (when record specified)
+
+Common Northbound tables: `Logical_Switch`, `Logical_Router`, `Logical_Switch_Port`, `Logical_Router_Port`, `ACL`, `Address_Set`, `Port_Group`, `Load_Balancer`, `NAT`
+
+Common Southbound tables: `Chassis`, `Port_Binding`, `Datapath_Binding`, `Logical_Flow`, `MAC_Binding`, `Multicast_Group`, `SB_Global`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | no | — | Kubernetes namespace of the OVN pod |
+| `name` | string | **yes** | — | Name of the pod running OVN |
+| `database` | string | **yes** | — | OVN database to query - `"nbdb"` for Northbound or `"sbdb"` for Southbound |
+| `table` | string | **yes** | — | Name of the table (e.g., `"Logical_Switch"`, `"Port_Binding"`) |
+| `record` | string | no | lists all records | Record identifier (UUID or name). If not specified, lists all records |
+| `columns` | string | no | — | Comma-separated list of columns to display (e.g., `"name,_uuid,ports"`) |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) (only when listing all records) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "database": "nbdb",
+  "table": "Port_Group"
+}
+```
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "database": "nbdb",
+  "table": "Logical_Router",
+  "record": "ovn_cluster_router"
+}
+```
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "database": "nbdb",
+  "table": "Logical_Switch",
+  "columns": "name,ports"
+}
+```
+
+---
+
+## ovn-lflow-list
+
+Runs `ovn-sbctl lflow-list` to retrieve logical flows which represent the compiled logical network pipeline. This is essential for debugging packet forwarding.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | no | — | Kubernetes namespace of the OVN pod |
+| `name` | string | **yes** | — | Name of the pod running OVN |
+| `datapath` | string | no | — | Datapath name or UUID to filter flows for a specific logical switch/router |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes"
+}
+```
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "datapath": "node1",
+  "pattern": "inport.*pod1",
+  "head": 200
+}
+```
+
+---
+
+## ovn-trace
+
+Runs `ovn-trace` to simulate packet processing through the logical network pipeline. This shows which logical flows match, what actions are taken, and the final disposition.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | no | — | Kubernetes namespace of the OVN pod |
+| `name` | string | **yes** | — | Name of the pod running OVN |
+| `datapath` | string | **yes** | — | Name of the logical switch or router to start the trace |
+| `microflow` | string | **yes** | — | Microflow specification describing the packet (e.g., `"inport==\"pod1\" && eth.src==00:00:00:00:00:01 && ip4.src==10.244.0.5 && ip4.dst==10.244.1.5"`) |
+| `mode` | string | no | `"detailed"` | Output verbosity mode - `"detailed"` (default), `"summary"`, or `"minimal"` |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "datapath": "node1",
+  "microflow": "inport==\"pod1\" && eth.src==00:00:00:00:00:01 && ip4.src==10.244.0.5 && ip4.dst==10.244.1.5"
+}
+```
+
+```json
+{
+  "name": "ovnkube-node-xxxxx",
+  "namespace": "ovn-kubernetes",
+  "datapath": "node1",
+  "microflow": "inport==\"pod1\" && eth.src==00:00:00:00:00:01 && icmp && ip4.src==10.244.0.5 && ip4.dst==8.8.8.8",
+  "mode": "summary"
+}
+```

--- a/docs/ovs.md
+++ b/docs/ovs.md
@@ -1,0 +1,137 @@
+# OVS tools
+
+Live-cluster tools that exec into an ovnkube-node pod to inspect Open vSwitch. Available with `--mode live-cluster` or `--mode dual`.
+
+See also: [User guide](user-guide.md) (including [common parameters](user-guide.md#common-parameters))
+
+| Tool | Description |
+|------|-------------|
+| [`ovs-vsctl`](#ovs-vsctl) | Run an ovs-vsctl command against an ovnkube-node pod to inspect the OVS switch configuration |
+| [`ovs-ofctl`](#ovs-ofctl) | Run an ovs-ofctl command against an ovnkube-node pod to inspect the OpenFlow state of an OVS bridge |
+| [`ovs-appctl`](#ovs-appctl) | Run an ovs-appctl command against an ovnkube-node pod to interact with the OVS daemons for datapath and OpenFlow debugging |
+
+---
+
+## ovs-vsctl
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | **yes** | — | Kubernetes namespace of the OVS pod |
+| `name` | string | **yes** | — | Name of the pod running OVS |
+| `action` | string | **yes** | — | The ovs-vsctl subcommand to run. `show`: Display a comprehensive overview of OVS configuration in a hierarchical format (bridges, ports, interfaces, controllers). `list-br`: List all OVS bridges on the pod. `list-ports`: List all ports on a specific OVS bridge (requires bridge). `list-ifaces`: List all interfaces on a specific OVS bridge (requires bridge) |
+| `bridge` | string | required for `list-ports` and `list-ifaces` | — | Name of the OVS bridge (e.g., `"br-int"`) |
+
+Also accepts common [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting) when `action` is `show`.
+
+### Examples
+
+```json
+{"namespace": "ovn-kubernetes", "name": "ovnkube-node-xxxxx", "action": "show"}
+```
+
+```json
+{"namespace": "ovn-kubernetes", "name": "ovnkube-node-xxxxx", "action": "list-br"}
+```
+
+```json
+{
+  "namespace": "ovn-kubernetes",
+  "name": "ovnkube-node-xxxxx",
+  "action": "list-ports",
+  "bridge": "br-int"
+}
+```
+
+```json
+{
+  "namespace": "ovn-kubernetes",
+  "name": "ovnkube-node-xxxxx",
+  "action": "list-ifaces",
+  "bridge": "br-int"
+}
+```
+
+---
+
+## ovs-ofctl
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | **yes** | — | Kubernetes namespace of the OVS pod |
+| `name` | string | **yes** | — | Name of the pod running OVS |
+| `action` | string | **yes** | — | The ovs-ofctl subcommand to run. `dump-flows`: Dump the OpenFlow flow entries programmed on the specified bridge |
+| `bridge` | string | **yes** | — | Name of the OVS bridge (e.g., `"br-int"`) |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "namespace": "ovn-kubernetes",
+  "name": "ovnkube-node-xxxxx",
+  "action": "dump-flows",
+  "bridge": "br-int"
+}
+```
+
+```json
+{
+  "namespace": "ovn-kubernetes",
+  "name": "ovnkube-node-xxxxx",
+  "action": "dump-flows",
+  "bridge": "br-int",
+  "pattern": "table=0",
+  "head": 50
+}
+```
+
+---
+
+## ovs-appctl
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | string | **yes** | — | Kubernetes namespace of the OVS pod |
+| `name` | string | **yes** | — | Name of the pod running OVS |
+| `action` | string | **yes** | — | The ovs-appctl subcommand to run. `dpctl/dump-conntrack`: Dump connection tracking entries from the OVS datapath. `ofproto/trace`: Simulate packet processing through the OpenFlow pipeline (requires bridge and flow) |
+| `bridge` | string | required for `ofproto/trace` | — | Name of the OVS bridge (e.g., `"br-int"`) |
+| `flow` | string | required for `ofproto/trace` | — | Flow specification describing the packet to trace (e.g., `"in_port=1,ip,nw_src=10.244.0.5,nw_dst=10.96.0.1"`) |
+| `additional_params` | string[] | no (only used when action is `"dpctl/dump-conntrack"`) | — | Additional CLI arguments to pass to dpctl/dump-conntrack (e.g., `["zone=5"]`) |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "namespace": "ovn-kubernetes",
+  "name": "ovnkube-node-xxxxx",
+  "action": "dpctl/dump-conntrack"
+}
+```
+
+```json
+{
+  "namespace": "ovn-kubernetes",
+  "name": "ovnkube-node-xxxxx",
+  "action": "dpctl/dump-conntrack",
+  "additional_params": ["zone=5"]
+}
+```
+
+```json
+{
+  "namespace": "ovn-kubernetes",
+  "name": "ovnkube-node-xxxxx",
+  "action": "ofproto/trace",
+  "bridge": "br-int",
+  "flow": "in_port=1,ip,nw_src=10.244.0.5,nw_dst=10.96.0.1"
+}
+```

--- a/docs/sosreport.md
+++ b/docs/sosreport.md
@@ -1,0 +1,188 @@
+# Sosreport tools
+
+Offline tools for browsing extracted sosreport archives. Available with `--mode offline` or `--mode dual`.
+
+`sosreport_path` must point at an **extracted** directory on disk (not a `.tar.xz` / archive file); it needs `sos_commands/` and `sos_reports/manifest.json`. `sos-get-pod-logs` additionally requires the sosreport `container_log` plugin with copied logs named `<pod>_<namespace>_<container>-<id>.log`.
+
+See also: [User guide](user-guide.md) (including [common parameters](user-guide.md#common-parameters))
+
+| Tool | Description |
+|------|-------------|
+| [`sos-list-plugins`](#sos-list-plugins) | List enabled sosreport plugins with their command counts |
+| [`sos-list-commands`](#sos-list-commands) | List all commands collected by a specific sosreport plugin |
+| [`sos-search-commands`](#sos-search-commands) | Search for commands across all plugins by pattern |
+| [`sos-get-command`](#sos-get-command) | Get command output using filepath from manifest |
+| [`sos-get-pod-logs`](#sos-get-pod-logs) | Get Kubernetes pod container logs from a sosreport |
+
+---
+
+## sos-list-plugins
+
+Returns a list of plugins with the number of commands collected by each plugin.
+
+Use this to discover which plugins are available, then use `sos-list-commands` to see what commands are available within a specific plugin.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sosreport_path` | string | **yes** | — | Path to extracted sosreport directory |
+
+### Examples
+
+```json
+{"sosreport_path": "/path/to/sosreport-hostname-20240101"}
+```
+
+---
+
+## sos-list-commands
+
+Returns all commands executed by the plugin with their filepaths. Use the filepath with `sos-get-command` to retrieve the actual command output.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sosreport_path` | string | **yes** | — | Path to extracted sosreport directory |
+| `plugin` | string | **yes** | — | Plugin name (e.g. `"openvswitch"`, `"networking"`, `"kubernetes"`) |
+
+### Examples
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "plugin": "openvswitch"
+}
+```
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "plugin": "networking"
+}
+```
+
+---
+
+## sos-search-commands
+
+Searches command names and filepaths across all plugins. Returns matching commands with their plugin, exec string, and filepath. Does NOT return file contents.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sosreport_path` | string | **yes** | — | Path to extracted sosreport directory |
+| `pattern` | string | **yes** | — | Regex pattern to search in command exec and filepath |
+| `max_results` | integer | no | `100` | Maximum results to return |
+
+### Examples
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "pattern": "iptables"
+}
+```
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "pattern": "ovn.*show"
+}
+```
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "pattern": "journalctl.*kubelet"
+}
+```
+
+---
+
+## sos-get-command
+
+Use the filepath returned by `sos-list-commands` or `sos-search-commands` to retrieve the actual command output. Supports optional grep-style filtering.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sosreport_path` | string | **yes** | — | Path to extracted sosreport directory |
+| `filepath` | string | **yes** | — | Relative filepath from `sos-list-commands` or `sos-search-commands` |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "filepath": "sos_commands/openvswitch/ovs-vsctl_-t_5_show"
+}
+```
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "filepath": "sos_commands/firewall_tables/iptables_-vnxL",
+  "pattern": "KUBE-"
+}
+```
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "filepath": "sos_commands/openvswitch/ovs-vsctl_-t_5_show",
+  "tail": 50
+}
+```
+
+---
+
+## sos-get-pod-logs
+
+Reads container logs collected from the sosreport for the specified pod. Returns log lines. If `container` is omitted, returns the first matching container log for the pod.
+
+Requires the sosreport’s `container_log` plugin (missing or empty yields “No pod logs found in sosreport”) with copied logs under the usual `<pod>_<namespace>_<container>-<id>.log` layout.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sosreport_path` | string | **yes** | — | Path to extracted sosreport directory |
+| `namespace` | string | **yes** | — | Pod namespace |
+| `name` | string | **yes** | — | Pod name |
+| `container` | string | no | — | Container name. If omitted, returns the first matching container log for the pod |
+
+Also accepts common [`pattern`](user-guide.md#pattern-filtering) and [`head` / `tail` / `apply_tail_first`](user-guide.md#head--tail-line-limiting).
+
+### Examples
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "namespace": "openshift-ovn-kubernetes",
+  "name": "ovnkube-node-abc"
+}
+```
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "namespace": "openshift-ovn-kubernetes",
+  "name": "ovnkube-node-abc",
+  "container": "ovnkube-controller"
+}
+```
+
+```json
+{
+  "sosreport_path": "/path/to/sosreport-hostname-20240101",
+  "namespace": "openshift-ovn-kubernetes",
+  "name": "ovnkube-node-abc",
+  "pattern": "ERROR.*"
+}
+```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,86 @@
+# User Guide
+
+This guide documents every tool exposed by the **ovn-kubernetes-mcp** server. Use it alongside the [README](../README.md) for installation, operating modes, and connection setup.
+
+## Operating modes and tool availability
+
+| Mode | Available categories |
+|------|----------------------|
+| `live-cluster` (default) | [kubernetes](kubernetes.md), [ovn](ovn.md), [ovs](ovs.md), [kernel](kernel.md), [network-tools](network-tools.md) |
+| `offline` | [sosreport](sosreport.md), [must-gather](must-gather.md) |
+| `dual` | All categories above (live-cluster tools still need a kubeconfig or in-cluster credentials) |
+
+You can hide categories or individual tools with `--disable-categories` and `--disable-tools`. See [Selectively exposing tools](../README.md#selectively-exposing-tools) in the README.
+
+## Common parameters
+
+Some tools reuse the same optional fields for output limiting, filtering, or per-call timeouts. **Support is not universal** — see the matrix below. Category pages list only tool-specific parameters and link here for shared fields.
+
+| Category | `head` / `tail` / `apply_tail_first` | `pattern` | `timeout_seconds` | Notes |
+|----------|--------------------------------------|-----------|-------------------|-------|
+| [kubernetes](kubernetes.md) | `pod-logs` only | `pod-logs` only | — | `resource-get` / `resource-list` use neither |
+| [ovn](ovn.md) | all tools | `ovn-get`, `ovn-lflow-list`, `ovn-trace` | — | `ovn-show` has head/tail only |
+| [ovs](ovs.md) | most tools (`ovs-vsctl` only when `action=show`) | `ovs-ofctl`, `ovs-appctl` | — | |
+| [kernel](kernel.md) | all tools | — | all tools | |
+| [network-tools](network-tools.md) | — | — | all tools | Packet matching uses `bpf_filter`, not `pattern` |
+| [sosreport](sosreport.md) | `sos-get-command`, `sos-get-pod-logs` | `sos-get-command`, `sos-get-pod-logs`; `sos-search-commands` for exec/filepath search | — | `sos-search-commands` also has `max_results` |
+| [must-gather](must-gather.md) | `must-gather-pod-logs` only | `must-gather-pod-logs` only | — | Other must-gather tools use neither |
+
+### Head / tail line limiting
+
+Used by tools marked in the matrix above.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `head` | integer | `100` lines if `tail` is not specified | Return only first N lines |
+| `tail` | integer | — | Return only last N lines |
+| `apply_tail_first` | boolean | `false` | If both head and tail are set and apply_tail_first is true, apply tail before head |
+
+### Pattern filtering
+
+Used by tools marked in the matrix above (grep-style line filtering unless a tool defines different semantics).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `pattern` | string | — | Regex pattern to filter log/output lines |
+
+### Per-call timeout
+
+Used by [kernel](kernel.md) and [network-tools](network-tools.md) only. Other categories rely on the server `--tool-timeout` without a per-call override field.
+
+The server default is **120 seconds** via `--tool-timeout` (`0` disables the global timeout); per-call `timeout_seconds` overrides that value and is capped at **300** seconds.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `timeout_seconds` | integer | server `--tool-timeout` (**120**) | Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is 300 seconds |
+
+## Tool categories
+
+### Live Cluster Mode
+
+Available with `--mode live-cluster` or `--mode dual`.
+
+| Category | Description |
+|----------|-------------|
+| [kubernetes](kubernetes.md) | Pod logs and Kubernetes resource get/list |
+| [ovn](ovn.md) | OVN Northbound/Southbound introspection and packet tracing |
+| [ovs](ovs.md) | Open vSwitch configuration, OpenFlow flows, and datapath debugging |
+| [kernel](kernel.md) | Node-level conntrack, iptables, nftables, and `ip` commands |
+| [network-tools](network-tools.md) | Packet capture (`tcpdump`) and kernel stack tracing (`pwru`) |
+
+### Offline Mode
+
+Available with `--mode offline` or `--mode dual`. No cluster access required.
+
+| Category | Description |
+|----------|-------------|
+| [sosreport](sosreport.md) | Browse and search extracted sosreport archives |
+| [must-gather](must-gather.md) | Query must-gather archives (Kubernetes resources, logs, OVN databases) |
+
+## Prerequisites by category
+
+| Category | Requirements |
+|----------|--------------|
+| Live-cluster tools | Valid kubeconfig, or in-cluster ServiceAccount credentials |
+| [must-gather](must-gather.md) | [`omc`](https://github.com/gmeghnag/omc) on `PATH`. Database list/query tools also need [`ovsdb-tool`](https://www.openvswitch.org/support/dist-docs/ovsdb-tool.1.txt) |
+| [sosreport](sosreport.md) | Extracted sosreport directory containing `sos_commands/` and `sos_reports/manifest.json`. `sos-get-pod-logs` also needs the `container_log` plugin (`<pod>_<namespace>_<container>-<id>.log`) |

--- a/pkg/kernel/mcp/mcp.go
+++ b/pkg/kernel/mcp/mcp.go
@@ -45,7 +45,7 @@ func (s *MCPServer) AddTools(server *mcp.Server) {
 Parameters:
 - node (required): Name of the node from where conntrack entries are expected to be extracted
 - namespace (optional): Namespace of the debug pod from where conntrack entries are expected to be extracted. Default: 'default'
-- command (optional): These options specify the particular operation to perform. These options can only be used if configured image has 'conntrack' utility available.
+- command (optional): These options specify the particular operation to perform. These options can only be used if configured image has 'conntrack' utility available. If omitted or empty, defaults to -L. 
 					  -L, --dump : List connection tracking table.
 					  -C, --count: Show the table counter.
 					  -S, --stats: Show the in-kernel connection tracking system statistics.
@@ -85,7 +85,7 @@ Parameters:
 					mangle	: This table is used for specialized packet alteration.
 					raw   	: This table is used mainly for configuring exemptions from connection tracking in combination with the NOTRACK target.
 					security: This table is used for Mandatory Access Control (MAC) networking rules.
-- command (required): These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below.
+- command (optional): These options specify the desired action to perform. Only one of them can be specified on the command line unless otherwise stated below. If omitted or empty, defaults to -L.
 					  -L, --list [chain]       : List all rules in the selected chain. If no chain is selected, all chains are listed.
 					  -S, --list-rules [chain] : Print all rules in the selected chain. If no chain is selected, all chains are printed like iptables-save.
 - filter_parameters (optional): These parameters are useful to filter certain entries from the whole table:
@@ -103,7 +103,8 @@ apply tail before head. Default: false
 - timeout_seconds (optional): Timeout in seconds for the command execution. If not specified, server default timeout is used. The maximum value is %d seconds.
 							
 Example:
-- node='ovn-control-plane', table='nat', command='-L', filter_parameters='-nv4'	
+- node='ovn-control-plane', table='nat', filter_parameters='-nv4'
+- node='ovn-control-plane', table='nat', command='-L'
 Example output:
 Chain POSTROUTING (policy ACCEPT 675K packets, 41M bytes)
  pkts bytes target     prot opt in     out     source               destination         
@@ -125,7 +126,7 @@ Parameters:
 					- list sets      : Display the elements in the specified set.
 					- list maps      : Display the elements in the specified map.
 					- list flowtables: List all flowtables.
-- address_families (optional): Address families determine the type of packets which are processed. For each address family, the kernel contains so called hooks at specific stages of
+- address_families (optional): Address families determine the type of packets which are processed. For each address family, the kernel contains so-called hooks at specific stages of
        						   the packet processing paths, which invoke nftables if rules for these hooks exist.
 							   - ip       IPv4 address family.
                                - ip6      IPv6 address family.
@@ -153,7 +154,7 @@ table inet ovn-kubernetes
 Parameters:
 - node (required): Name of the node on which ip command is expected to be executed
 - namespace (optional): Namespace of the debug pod on which ip command is expected to be executed. Default: 'default'
-- options (optional): These options helps in providing more details or formattig output data.
+- options (optional): These options helps in providing more details or formatting output data.
                       -d, -details        : Output more detailed information.
 					  -4                  : shortcut for -family inet.
 					  -6                  : shortcut for -family inet6.

--- a/pkg/kernel/types/types.go
+++ b/pkg/kernel/types/types.go
@@ -27,7 +27,7 @@ type ListConntrackParams struct {
 type ListIPTablesParams struct {
 	CommonParams
 	Table            string `json:"table,omitempty"`             // Table specifies the iptables table to query (e.g., "filter", "nat", "mangle", "raw")
-	Command          string `json:"command"`                     // Command specifies the iptables command to execute (e.g., "iptables", "ip6tables")
+	Command          string `json:"command,omitempty"`           // Command specifies the iptables action (e.g., "-L", "-S"). If omitted or empty, defaults to "-L"
 	FilterParameters string `json:"filter_parameters,omitempty"` // FilterParameters specifies additional filter criteria for iptables rules
 }
 

--- a/pkg/network-tools/mcp/mcp.go
+++ b/pkg/network-tools/mcp/mcp.go
@@ -52,8 +52,6 @@ func (s *MCPServer) AddTools(server *mcp.Server) {
 Supports both node-level and pod-level packet capture with BPF filtering.
 
 This tool creates a specialized debug pod on the specified node for node-level captures.
-The node image can be configured via --tcpdump-image flag or will default to nicolaka/netshoot:v0.13.
-The image must contain the tcpdump utility
 
 Parameters:
 - target_type: 'node' or 'pod' (required)
@@ -82,8 +80,6 @@ drops, routing issues, and understanding the kernel's packet processing path.
 
 This tool creates a specialized debug pod on the specified node with necessary eBPF capabilities
 to trace packets through kernel networking functions.
-The node image can be configured via --pwru-image flag or will default to docker.io/cilium/pwru:v1.0.10.
-The image must contain the pwru utility
 
 Parameters:
 - node_name: Name of the node to run pwru on (required)

--- a/pkg/ovn/mcp/mcp.go
+++ b/pkg/ovn/mcp/mcp.go
@@ -42,7 +42,7 @@ For Southbound (sbdb): Runs 'ovn-sbctl show' and displays chassis information, p
 and their relationships.
 
 Parameters:
-- namespace: Kubernetes namespace of the OVN pod (e.g., "openshift-ovn-kubernetes")
+- namespace: Kubernetes namespace of the OVN pod (e.g., "ovn-kubernetes")
 - name: Name of the pod running OVN (e.g., "ovnkube-node-xxxxx")
 - database: OVN database to query - "nbdb" for Northbound or "sbdb" for Southbound
 - head (optional): Return only first N lines. Default: %d lines if tail is not specified

--- a/pkg/sosreport/mcp/mcp.go
+++ b/pkg/sosreport/mcp/mcp.go
@@ -121,7 +121,7 @@ Parameters:
 apply tail before head. Default: false
 
 Reads container logs collected from the sosreport for the specified pod. Returns
-log lines with the log file path.
+log lines.
 
 Examples:
 - namespace='openshift-ovn-kubernetes', name='ovnkube-node-abc'


### PR DESCRIPTION
Fixes #85 

Introduce docs/user-guide.md and category pages for kubernetes, OVN, OVS, kernel, network-tools, sosreport, and must-gather, including common parameters and prerequisites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added a full **User Guide** with operating modes, available tool categories, common parameters, filtering, and timeout/output-limit guidance.
  * Created/expanded live-cluster tooling pages (**kernel, Kubernetes, network, OVN, OVS**) and offline tools (**must-gather, sosreport**), including parameter tables and JSON examples.
  * Updated the README to link directly to the User Guide.

* **Bug Fixes**
  * Made **iptables** `command` optional; omitting it now defaults to list mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->