### PR TITLE
sosreport: reuse shared params and mirror kubernetes/must-gather pod logs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Available when running with `--mode offline` or `--mode dual`. No cluster access
 | | `sos-list-commands` | List all commands collected by a specific sosreport plugin. |
 | | `sos-search-commands` | Search for commands across all plugins by pattern. |
 | | `sos-get-command` | Get command output using filepath from manifest. |
-| | `sos-search-pod-logs` | Search Kubernetes pod container logs. |
+| | `sos-get-pod-logs` | Get Kubernetes pod container logs from a sosreport. |
 | **must-gather** | `must-gather-get-resource` | Get a specific Kubernetes resource from a must-gather archive. |
 | | `must-gather-list-resources` | List Kubernetes resources of a specific kind from a must-gather archive. |
 | | `must-gather-pod-logs` | Get container logs from a pod in a must-gather archive. |

--- a/pkg/middleware/toolfilter/toolfilter.go
+++ b/pkg/middleware/toolfilter/toolfilter.go
@@ -22,7 +22,7 @@ var toolsByCategory = map[string][]string{
 	"ovs":           {"ovs-vsctl", "ovs-ofctl", "ovs-appctl"},
 	"kernel":        {"get-conntrack", "get-iptables", "get-nft", "get-ip"},
 	"network-tools": {"tcpdump", "pwru"},
-	"sosreport":     {"sos-list-plugins", "sos-list-commands", "sos-search-commands", "sos-get-command", "sos-search-pod-logs"},
+	"sosreport":     {"sos-list-plugins", "sos-list-commands", "sos-search-commands", "sos-get-command", "sos-get-pod-logs"},
 	"must-gather":   {"must-gather-get-resource", "must-gather-list-resources", "must-gather-pod-logs", "must-gather-ovnk-info", "must-gather-list-northbound-databases", "must-gather-list-southbound-databases", "must-gather-query-database"},
 }
 

--- a/pkg/sosreport/mcp/commands.go
+++ b/pkg/sosreport/mcp/commands.go
@@ -5,18 +5,23 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
+	"strings"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/pattern"
 )
 
 const (
-	// defaultResultLimit is the default maximum number of lines/results to return
-	defaultResultLimit = 100
+	// DefaultMaxLines is the default max lines returned when head/tail are unset.
+	DefaultMaxLines = 100
+	// DefaultMaxResults is the default max matches for sos-search-commands.
+	DefaultMaxResults = 100
 )
 
 // getCommandOutput reads a command output file by filepath from manifest
-func getCommandOutput(sosreportPath, relativeFilepath, pattern string, maxLines int) (string, error) {
+func getCommandOutput(sosreportPath, relativeFilepath string, patternParams pattern.PatternParams, headTailParams headtail.HeadTailParams) (string, error) {
 	if err := validateSosreportPath(sosreportPath); err != nil {
 		return "", err
 	}
@@ -41,28 +46,23 @@ func getCommandOutput(sosreportPath, relativeFilepath, pattern string, maxLines 
 		}
 	}()
 
-	var searchPattern *regexp.Regexp
-	if pattern != "" {
-		searchPattern, err = regexp.Compile(pattern)
+	lines, err := patternParams.ExecuteWithMatch(func() ([]string, error) {
+		fileLines, err := readLines(file)
 		if err != nil {
-			return "", fmt.Errorf("invalid pattern: %w", err)
+			return nil, err
 		}
-	}
-
-	if maxLines <= 0 {
-		maxLines = defaultResultLimit
-	}
-
-	output, err := readWithLimit(file, searchPattern, maxLines)
+		return utils.StripEmptyLines(fileLines), nil
+	}, true)
 	if err != nil {
 		return "", err
 	}
 
-	if output == "" && pattern != "" {
-		return fmt.Sprintf("No lines matching pattern %q found\n", pattern), nil
+	if len(lines) == 0 && patternParams.Pattern != "" {
+		return fmt.Sprintf("No lines matching pattern %q found\n", patternParams.Pattern), nil
 	}
 
-	return output, nil
+	lines = headTailParams.Apply(lines, DefaultMaxLines)
+	return strings.Join(lines, "\n"), nil
 }
 
 // listPlugins returns a list of enabled plugins with their command counts
@@ -118,27 +118,36 @@ func listCommands(sosreportPath, pluginName string) (types.ListCommandsResult, e
 }
 
 // searchCommands searches for commands matching a pattern across all plugins
-func searchCommands(sosreportPath, pattern string, maxResults int) (types.SearchCommandsResult, error) {
+func searchCommands(sosreportPath string, patternParams pattern.PatternParams, maxResults int) (types.SearchCommandsResult, error) {
 	manifest, err := loadManifest(sosreportPath)
 	if err != nil {
 		return types.SearchCommandsResult{}, err
-	}
-
-	searchPattern, err := regexp.Compile(pattern)
-	if err != nil {
-		return types.SearchCommandsResult{}, fmt.Errorf("invalid search pattern: %w", err)
 	}
 
 	result := types.SearchCommandsResult{
 		Matches: []types.CommandMatch{},
 	}
 	if maxResults <= 0 {
-		maxResults = defaultResultLimit
+		maxResults = DefaultMaxResults
 	}
 
 	for pluginName, plugin := range manifest.Components.Report.Plugins {
 		for _, cmd := range plugin.Commands {
-			if searchPattern.MatchString(cmd.Exec) || searchPattern.MatchString(cmd.Filepath) {
+			execMatches, err := patternParams.ExecuteWithMatch(func() ([]string, error) {
+				return []string{cmd.Exec}, nil
+			}, true)
+			if err != nil {
+				return types.SearchCommandsResult{}, err
+			}
+
+			filepathMatches, err := patternParams.ExecuteWithMatch(func() ([]string, error) {
+				return []string{cmd.Filepath}, nil
+			}, true)
+			if err != nil {
+				return types.SearchCommandsResult{}, err
+			}
+
+			if len(execMatches) == 1 || len(filepathMatches) == 1 {
 				result.Matches = append(result.Matches, types.CommandMatch{
 					Plugin:   pluginName,
 					Exec:     cmd.Exec,

--- a/pkg/sosreport/mcp/commands_test.go
+++ b/pkg/sosreport/mcp/commands_test.go
@@ -3,29 +3,32 @@ package sosreport
 import (
 	"strings"
 	"testing"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/pattern"
 )
 
 const sosreportTestData = "testdata/sosreport"
 
 func TestGetCommandOutput(t *testing.T) {
 	tests := []struct {
-		name         string
-		sosreport    string
-		filepath     string
-		pattern      string
-		maxLines     int
-		wantError    bool
-		errorMsg     string
-		wantContains string
-		wantMinLines int
-		wantMaxLines int
+		name           string
+		sosreport      string
+		filepath       string
+		pattern        string
+		head           int
+		tail           int
+		wantError      bool
+		errorMsg       string
+		wantContains   string
+		wantMinLines   int
+		wantMaxLines   int
+		wantExactLines int
 	}{
 		{
 			name:         "get ovs-vsctl output without pattern",
 			sosreport:    sosreportTestData,
 			filepath:     "sos_commands/openvswitch/ovs-vsctl_-t_5_show",
-			pattern:      "",
-			maxLines:     0,
 			wantError:    false,
 			wantContains: "Bridge br-int",
 			wantMinLines: 1,
@@ -34,8 +37,6 @@ func TestGetCommandOutput(t *testing.T) {
 			name:         "get ovs-ofctl output without pattern",
 			sosreport:    sosreportTestData,
 			filepath:     "sos_commands/openvswitch/ovs-ofctl_dump-flows_br-int",
-			pattern:      "",
-			maxLines:     0,
 			wantError:    false,
 			wantContains: "cookie=0x0",
 			wantMinLines: 1,
@@ -44,8 +45,6 @@ func TestGetCommandOutput(t *testing.T) {
 			name:         "get ip addr show output",
 			sosreport:    sosreportTestData,
 			filepath:     "sos_commands/networking/ip_addr_show",
-			pattern:      "",
-			maxLines:     0,
 			wantError:    false,
 			wantContains: "lo:",
 			wantMinLines: 1,
@@ -55,27 +54,30 @@ func TestGetCommandOutput(t *testing.T) {
 			sosreport:    sosreportTestData,
 			filepath:     "sos_commands/networking/ip_addr_show",
 			pattern:      "NOTFOUND",
-			maxLines:     0,
 			wantError:    false,
 			wantContains: "No lines matching pattern",
 			wantMinLines: 1,
 		},
 		{
-			name:         "limit max lines",
-			sosreport:    sosreportTestData,
-			filepath:     "sos_commands/networking/ip_addr_show",
-			pattern:      "",
-			maxLines:     2,
-			wantError:    false,
-			wantContains: "output truncated",
-			wantMaxLines: 2,
+			name:           "limit with head",
+			sosreport:      sosreportTestData,
+			filepath:       "sos_commands/networking/ip_addr_show",
+			head:           2,
+			wantError:      false,
+			wantExactLines: 2,
+		},
+		{
+			name:           "limit with tail",
+			sosreport:      sosreportTestData,
+			filepath:       "sos_commands/networking/ip_addr_show",
+			tail:           2,
+			wantError:      false,
+			wantExactLines: 2,
 		},
 		{
 			name:      "non-existent file",
 			sosreport: sosreportTestData,
 			filepath:  "sos_commands/non-existent-file",
-			pattern:   "",
-			maxLines:  0,
 			wantError: true,
 			errorMsg:  "command output file not found",
 		},
@@ -83,8 +85,6 @@ func TestGetCommandOutput(t *testing.T) {
 			name:      "invalid sosreport path",
 			sosreport: "testdata/non-existent",
 			filepath:  "sos_commands/openvswitch/ovs-vsctl_-t_5_show",
-			pattern:   "",
-			maxLines:  0,
 			wantError: true,
 			errorMsg:  "sosreport path does not exist",
 		},
@@ -93,15 +93,16 @@ func TestGetCommandOutput(t *testing.T) {
 			sosreport: sosreportTestData,
 			filepath:  "sos_commands/networking/ip_addr_show",
 			pattern:   "[invalid(",
-			maxLines:  0,
 			wantError: true,
-			errorMsg:  "invalid pattern",
+			errorMsg:  "invalid search pattern",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output, err := getCommandOutput(tt.sosreport, tt.filepath, tt.pattern, tt.maxLines)
+			output, err := getCommandOutput(tt.sosreport, tt.filepath,
+				pattern.PatternParams{Pattern: tt.pattern},
+				headtail.HeadTailParams{Head: tt.head, Tail: tt.tail})
 			if tt.wantError {
 				if err == nil {
 					t.Errorf("getCommandOutput() expected error but got nil")
@@ -115,17 +116,15 @@ func TestGetCommandOutput(t *testing.T) {
 				return
 			}
 
-			// Check for expected content
 			if tt.wantContains != "" && !strings.Contains(output, tt.wantContains) {
 				t.Errorf("getCommandOutput() output does not contain %q, got:\n%s", tt.wantContains, output)
 			}
 
-			// Check line count if specified (excluding truncation message and empty lines)
-			if tt.wantMinLines > 0 || tt.wantMaxLines > 0 {
+			if tt.wantMinLines > 0 || tt.wantMaxLines > 0 || tt.wantExactLines > 0 {
 				lines := strings.Split(output, "\n")
 				lineCount := 0
 				for _, line := range lines {
-					if line != "" && !strings.Contains(line, "output truncated") && !strings.HasPrefix(line, "...") {
+					if line != "" {
 						lineCount++
 					}
 				}
@@ -136,6 +135,10 @@ func TestGetCommandOutput(t *testing.T) {
 
 				if tt.wantMaxLines > 0 && lineCount > tt.wantMaxLines {
 					t.Errorf("getCommandOutput() got %d lines, want at most %d. Output:\n%s", lineCount, tt.wantMaxLines, output)
+				}
+
+				if tt.wantExactLines > 0 && lineCount != tt.wantExactLines {
+					t.Errorf("getCommandOutput() got %d lines, want exactly %d. Output:\n%s", lineCount, tt.wantExactLines, output)
 				}
 			}
 		})
@@ -329,7 +332,7 @@ func TestSearchCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := searchCommands(tt.path, tt.pattern, tt.maxResults)
+			result, err := searchCommands(tt.path, pattern.PatternParams{Pattern: tt.pattern}, tt.maxResults)
 			if tt.wantError {
 				if err == nil {
 					t.Errorf("searchCommands() expected error but got nil")

--- a/pkg/sosreport/mcp/logs.go
+++ b/pkg/sosreport/mcp/logs.go
@@ -7,15 +7,24 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
+	"unicode"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/pattern"
 )
 
-// searchPodLogs searches pod logs using the manifest to find log files
-func searchPodLogs(sosreportPath, pattern, podFilter string, maxResults int) (string, error) {
-	searchPattern, err := regexp.Compile(pattern)
-	if err != nil {
-		return "", fmt.Errorf("invalid search pattern: %w", err)
+// getPodLogs reads container logs for a specific pod from the sosreport manifest.
+// Log files use the containers naming layout:
+// <pod_name>_<namespace>_<container_name>-<container_id>.log
+// Returns the first matching container log (optionally filtered by container name).
+func getPodLogs(sosreportPath, namespace, name, container string, patternParams pattern.PatternParams, headTailParams headtail.HeadTailParams) (string, error) {
+	if namespace == "" {
+		return "", fmt.Errorf("namespace is required")
+	}
+	if name == "" {
+		return "", fmt.Errorf("name is required")
 	}
 
 	manifest, err := loadManifest(sosreportPath)
@@ -23,59 +32,112 @@ func searchPodLogs(sosreportPath, pattern, podFilter string, maxResults int) (st
 		return "", err
 	}
 
-	if maxResults <= 0 {
-		maxResults = defaultResultLimit
-	}
-
 	containerLogPlugin, exists := manifest.Components.Report.Plugins["container_log"]
 	if !exists || len(containerLogPlugin.Files) == 0 {
 		return "No pod logs found in sosreport\n", nil
 	}
 
-	var result strings.Builder
-	totalMatches := 0
+	var result []string
+	matchedAnyFile := false
 
 	for _, f := range containerLogPlugin.Files {
 		for _, logPath := range f.FilesCopied {
-			if podFilter != "" && !strings.Contains(logPath, podFilter) {
+			if !matchesContainerLogFile(logPath, namespace, name, container) {
 				continue
 			}
+			matchedAnyFile = true
 
 			// Remove the prefix if exists
-			logPath = strings.TrimPrefix(logPath, "host/")
+			trimmedPath := strings.TrimPrefix(logPath, "host/")
+			fullPath := filepath.Join(sosreportPath, trimmedPath)
 
-			fullPath := filepath.Join(sosreportPath, logPath)
-
-			matches, err := searchInFile(fullPath, searchPattern, maxResults-totalMatches)
+			matches, err := searchInFile(fullPath, patternParams)
 			if err != nil {
 				return "", err
 			}
 
 			if len(matches) > 0 {
-				fmt.Fprintf(&result, "\n=== %s ===\n", logPath)
-				result.WriteString(matches)
-				totalMatches += len(strings.Split(matches, "\n"))
-
-				if totalMatches >= maxResults {
-					fmt.Fprintf(&result, "\n... (search truncated at %d results)\n", maxResults)
-					return result.String(), nil
-				}
+				result = append(result, matches...)
 			}
+
+			// Stop after the first matching container log.
+			break
+		}
+		if matchedAnyFile {
+			break
 		}
 	}
-	if totalMatches == 0 {
-		return fmt.Sprintf("No matches found for pattern: %s\n", pattern), nil
+
+	if !matchedAnyFile {
+		if container != "" {
+			return fmt.Sprintf("No pod logs found for pod %s/%s container %q\n", namespace, name, container), nil
+		}
+		return fmt.Sprintf("No pod logs found for pod %s/%s\n", namespace, name), nil
+	}
+	if len(result) == 0 {
+		if patternParams.Pattern != "" {
+			return fmt.Sprintf("No matches found for pattern: %s\n", patternParams.Pattern), nil
+		}
+		return fmt.Sprintf("No log content found for pod %s/%s\n", namespace, name), nil
 	}
 
-	return result.String(), nil
+	result = headTailParams.Apply(result, DefaultMaxLines)
+	return strings.Join(result, "\n"), nil
+}
+
+// matchesContainerLogFile reports whether logPath is a container log for the
+// given pod. Filenames follow:
+// <pod_name>_<namespace>_<container_name>-<container_id>.log[.gz]
+// When container is non-empty, the container_name must match exactly.
+func matchesContainerLogFile(logPath, namespace, name, container string) bool {
+	base := filepath.Base(logPath)
+	base = strings.TrimSuffix(base, ".gz")
+	if !strings.HasSuffix(base, ".log") {
+		return false
+	}
+	base = strings.TrimSuffix(base, ".log")
+
+	prefix := name + "_" + namespace + "_"
+	if !strings.HasPrefix(base, prefix) {
+		return false
+	}
+	remainder := strings.TrimPrefix(base, prefix)
+	containerName, ok := parseContainerName(remainder)
+	if !ok {
+		return false
+	}
+	if container == "" {
+		return true
+	}
+	return containerName == container
+}
+
+// parseContainerName extracts <container_name> from remainder formatted as
+// <container_name>-<container_id>, where container_id is a non-empty hex string.
+func parseContainerName(remainder string) (string, bool) {
+	idx := strings.LastIndex(remainder, "-")
+	if idx <= 0 {
+		return "", false
+	}
+	containerName := remainder[:idx]
+	idPart := remainder[idx+1:]
+	if containerName == "" || idPart == "" {
+		return "", false
+	}
+	for _, r := range idPart {
+		if !unicode.Is(unicode.ASCII_Hex_Digit, r) {
+			return "", false
+		}
+	}
+	return containerName, true
 }
 
 // searchInFile searches in a file (handles both regular and gzip compressed files)
-// Returns the matches and an error
-func searchInFile(filePath string, pattern *regexp.Regexp, maxLines int) (string, error) {
+// Returns matching lines after pattern filtering
+func searchInFile(filePath string, patternParams pattern.PatternParams) ([]string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer func() {
 		err := file.Close()
@@ -89,7 +151,7 @@ func searchInFile(filePath string, pattern *regexp.Regexp, maxLines int) (string
 	if strings.HasSuffix(filePath, ".gz") {
 		gzReader, err := gzip.NewReader(file)
 		if err != nil {
-			return "", fmt.Errorf("failed to create gzip reader: %w", err)
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
 		}
 		defer func() {
 			err := gzReader.Close()
@@ -100,6 +162,11 @@ func searchInFile(filePath string, pattern *regexp.Regexp, maxLines int) (string
 		reader = gzReader
 	}
 
-	// Read with limit directly from the reader
-	return readWithLimit(reader, pattern, maxLines)
+	return patternParams.ExecuteWithMatch(func() ([]string, error) {
+		lines, err := readLines(reader)
+		if err != nil {
+			return nil, err
+		}
+		return utils.StripEmptyLines(lines), nil
+	}, true)
 }

--- a/pkg/sosreport/mcp/logs_test.go
+++ b/pkg/sosreport/mcp/logs_test.go
@@ -3,127 +3,249 @@ package sosreport
 import (
 	"strings"
 	"testing"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/pattern"
 )
 
-func TestSearchPodLogs(t *testing.T) {
+func TestGetPodLogs(t *testing.T) {
 	tests := []struct {
 		name           string
 		sosreport      string
+		namespace      string
+		podName        string
+		container      string
 		pattern        string
-		podFilter      string
-		maxResults     int
+		head           int
+		tail           int
 		wantError      bool
 		errorMsg       string
 		wantContains   string
+		wantNotContain string
 		wantMinMatches int
-		wantMaxMatches int
+		wantMaxLines   int
 	}{
 		{
-			name:           "search for ERROR in logs",
+			name:           "get first container when container omitted",
 			sosreport:      sosreportTestData,
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "ovnkube-node-abc",
+			wantContains:   "Starting ovnkube-controller",
+			wantNotContain: "northd",
+			wantMinMatches: 1,
+		},
+		{
+			name:           "get specific container",
+			sosreport:      sosreportTestData,
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "ovnkube-node-abc",
+			container:      "northd",
+			wantContains:   "Starting northd container",
+			wantNotContain: "Starting ovnkube-controller",
+			wantMinMatches: 1,
+		},
+		{
+			name:           "filter with pattern",
+			sosreport:      sosreportTestData,
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "ovnkube-node-abc",
+			container:      "ovnkube-controller",
 			pattern:        "ERROR",
-			podFilter:      "",
-			maxResults:     100,
-			wantError:      false,
 			wantContains:   "ERROR: Failed to connect",
 			wantMinMatches: 1,
 		},
 		{
-			name:           "filter by pod name",
+			name:           "pod not found",
 			sosreport:      sosreportTestData,
-			pattern:        ".*",
-			podFilter:      "ovnkube-node",
-			maxResults:     100,
-			wantError:      false,
-			wantContains:   "ovnkube-node",
-			wantMinMatches: 1,
-		},
-		{
-			name:           "filter by pod with no match",
-			sosreport:      sosreportTestData,
-			pattern:        ".*",
-			podFilter:      "non-existent-pod",
-			maxResults:     100,
-			wantError:      false,
-			wantContains:   "No matches found",
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "non-existent-pod",
+			wantContains:   "No pod logs found for pod",
 			wantMinMatches: 0,
 		},
 		{
-			name:           "search pattern with no matches",
+			name:           "container not found",
 			sosreport:      sosreportTestData,
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "ovnkube-node-abc",
+			container:      "missing-container",
+			wantContains:   "No pod logs found for pod",
+			wantMinMatches: 0,
+		},
+		{
+			name:           "pattern with no matches",
+			sosreport:      sosreportTestData,
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "ovnkube-node-abc",
+			container:      "ovnkube-controller",
 			pattern:        "NOTFOUND",
-			podFilter:      "",
-			maxResults:     100,
-			wantError:      false,
 			wantContains:   "No matches found",
 			wantMinMatches: 0,
 		},
 		{
-			name:           "limit max results",
+			name:           "does not match other pods",
 			sosreport:      sosreportTestData,
-			pattern:        ".*",
-			podFilter:      "",
-			maxResults:     2,
-			wantError:      false,
-			wantContains:   "search truncated",
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "ovnkube-node-abc",
+			pattern:        "ERROR",
+			wantContains:   "ERROR: Failed to connect",
+			wantNotContain: "Master failed cluster sync",
 			wantMinMatches: 1,
-			wantMaxMatches: 2,
 		},
 		{
-			name:       "invalid regex pattern",
-			sosreport:  sosreportTestData,
-			pattern:    "[invalid(",
-			podFilter:  "",
-			maxResults: 100,
-			wantError:  true,
-			errorMsg:   "invalid search pattern",
+			name:           "limit with head",
+			sosreport:      sosreportTestData,
+			namespace:      "openshift-ovn-kubernetes",
+			podName:        "ovnkube-node-abc",
+			head:           2,
+			wantMinMatches: 1,
+			wantMaxLines:   2,
 		},
 		{
-			name:       "invalid sosreport path",
-			sosreport:  "testdata/non-existent",
-			pattern:    "ERROR",
-			podFilter:  "",
-			maxResults: 100,
-			wantError:  true,
+			name:      "missing namespace",
+			sosreport: sosreportTestData,
+			namespace: "",
+			podName:   "ovnkube-node-abc",
+			wantError: true,
+			errorMsg:  "namespace is required",
+		},
+		{
+			name:      "missing name",
+			sosreport: sosreportTestData,
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "",
+			wantError: true,
+			errorMsg:  "name is required",
+		},
+		{
+			name:      "invalid regex pattern",
+			sosreport: sosreportTestData,
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			pattern:   "[invalid(",
+			wantError: true,
+			errorMsg:  "invalid search pattern",
+		},
+		{
+			name:      "invalid sosreport path",
+			sosreport: "testdata/non-existent",
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			wantError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := searchPodLogs(tt.sosreport, tt.pattern, tt.podFilter, tt.maxResults)
+			result, err := getPodLogs(tt.sosreport, tt.namespace, tt.podName, tt.container,
+				pattern.PatternParams{Pattern: tt.pattern},
+				headtail.HeadTailParams{Head: tt.head, Tail: tt.tail})
 			if tt.wantError {
 				if err == nil {
-					t.Errorf("searchPodLogs() expected error but got nil")
+					t.Errorf("getPodLogs() expected error but got nil")
 				} else if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
-					t.Errorf("searchPodLogs() error = %v, want error containing %q", err, tt.errorMsg)
+					t.Errorf("getPodLogs() error = %v, want error containing %q", err, tt.errorMsg)
 				}
 				return
 			}
 			if err != nil {
-				t.Errorf("searchPodLogs() unexpected error = %v", err)
+				t.Errorf("getPodLogs() unexpected error = %v", err)
 				return
 			}
 
-			// Check for expected content
 			if tt.wantContains != "" && !strings.Contains(result, tt.wantContains) {
-				t.Errorf("searchPodLogs() result does not contain %q, got:\n%s", tt.wantContains, result)
+				t.Errorf("getPodLogs() result does not contain %q, got:\n%s", tt.wantContains, result)
 			}
 
-			// For cases with no matches, we should get the "No matches found" message
-			if tt.wantMinMatches == 0 && !strings.Contains(result, "No matches found") {
-				t.Errorf("searchPodLogs() expected 'No matches found' message but didn't get it, got:\n%s", result)
+			if tt.wantNotContain != "" && strings.Contains(result, tt.wantNotContain) {
+				t.Errorf("getPodLogs() result unexpectedly contains %q, got:\n%s", tt.wantNotContain, result)
 			}
 
-			// For cases with matches, we shouldn't have the "No matches found" message
-			if tt.wantMinMatches > 0 && strings.Contains(result, "No matches found") {
-				t.Errorf("searchPodLogs() unexpected 'No matches found' message when matches were expected")
+			if tt.wantMinMatches == 0 && !strings.Contains(result, "No matches found") && !strings.Contains(result, "No pod logs found for pod") {
+				t.Errorf("getPodLogs() expected no-match message but didn't get it, got:\n%s", result)
 			}
 
-			// Check for truncation message when max results is set
-			if tt.maxResults > 0 && tt.wantMaxMatches > 0 && tt.wantMinMatches > 0 {
-				if !strings.Contains(result, "search truncated") && len(strings.Split(result, "\n")) > tt.maxResults {
-					t.Errorf("searchPodLogs() expected truncation message when max results exceeded")
+			if tt.wantMinMatches > 0 && (strings.Contains(result, "No matches found") || strings.Contains(result, "No pod logs found for pod")) {
+				t.Errorf("getPodLogs() unexpected no-match message when matches were expected")
+			}
+
+			if tt.wantMaxLines > 0 {
+				lines := strings.Split(result, "\n")
+				lineCount := 0
+				for _, line := range lines {
+					if line != "" {
+						lineCount++
+					}
 				}
+				if lineCount > tt.wantMaxLines {
+					t.Errorf("getPodLogs() got %d lines, want at most %d. Result:\n%s", lineCount, tt.wantMaxLines, result)
+				}
+			}
+		})
+	}
+}
+
+func TestMatchesContainerLogFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		logPath   string
+		namespace string
+		podName   string
+		container string
+		want      bool
+	}{
+		{
+			name:      "matches first container without container filter",
+			logPath:   "host/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_ovnkube-controller-deadbeef01.log",
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			want:      true,
+		},
+		{
+			name:      "matches specific container",
+			logPath:   "host/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_northd-cafebabe02.log",
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			container: "northd",
+			want:      true,
+		},
+		{
+			name:      "rejects wrong container",
+			logPath:   "host/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_northd-cafebabe02.log",
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			container: "ovnkube-controller",
+			want:      false,
+		},
+		{
+			name:      "rejects container name prefix",
+			logPath:   "host/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_ovnkube-controller-deadbeef01.log",
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			container: "ovnkube",
+			want:      false,
+		},
+		{
+			name:      "rejects different pod",
+			logPath:   "host/var/log/containers/ovnkube-control-plane-xyz_openshift-ovn-kubernetes_ovnkube-cluster-manager-feedface03.log",
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			want:      false,
+		},
+		{
+			name:      "supports gzip suffix",
+			logPath:   "var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_ovnkube-controller-deadbeef01.log.gz",
+			namespace: "openshift-ovn-kubernetes",
+			podName:   "ovnkube-node-abc",
+			container: "ovnkube-controller",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesContainerLogFile(tt.logPath, tt.namespace, tt.podName, tt.container)
+			if got != tt.want {
+				t.Errorf("matchesContainerLogFile(...) = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/sosreport/mcp/mcp.go
+++ b/pkg/sosreport/mcp/mcp.go
@@ -77,7 +77,7 @@ with their plugin, exec string, and filepath. Does NOT return file contents.
 Examples:
 - pattern='iptables' finds all iptables-related commands
 - pattern='ovn.*show' finds OVN show commands
-- pattern='journalctl.*kubelet' finds kubelet journal logs`, defaultResultLimit),
+- pattern='journalctl.*kubelet' finds kubelet journal logs`, DefaultMaxResults),
 		}, s.SearchCommands)
 
 	// Get command output
@@ -90,36 +90,44 @@ Parameters:
 - sosreport_path (required): Path to extracted sosreport directory
 - filepath (required): Relative filepath from sos-list-commands or sos-search-commands
 - pattern (optional): Regex pattern to filter output lines
-- max_lines (optional): Maximum lines to return (default: %d)
+- head (optional): Return only first N lines. Default: %d lines if tail is not specified
+- tail (optional): Return only last N lines
+- apply_tail_first (optional): If both head and tail are set and apply_tail_first is true,
+apply tail before head. Default: false
 
 Use the filepath returned by sos-list-commands or sos-search-commands to retrieve
 the actual command output. Supports optional grep-style filtering.
 
 Example:
 - filepath='sos_commands/openvswitch/ovs-vsctl_-t_5_show'
-- filepath='sos_commands/firewall_tables/iptables_-vnxL', pattern='KUBE-'`, defaultResultLimit),
+- filepath='sos_commands/firewall_tables/iptables_-vnxL', pattern='KUBE-'`, DefaultMaxLines),
 		}, s.GetCommand)
 
-	// Search pod logs
+	// Get pod logs
 	mcp.AddTool(server,
 		&mcp.Tool{
-			Name: "sos-search-pod-logs",
-			Description: fmt.Sprintf(`Search Kubernetes pod container logs.
+			Name: "sos-get-pod-logs",
+			Description: fmt.Sprintf(`Get Kubernetes pod container logs from a sosreport.
 
 Parameters:
 - sosreport_path (required): Path to extracted sosreport directory
-- pattern (required): Regex pattern to search for in logs
-- pod_filter (optional): Filter to specific pod/namespace substring
-- max_results (optional): Maximum result lines to return (default: %d)
+- namespace (required): Pod namespace
+- name (required): Pod name
+- container (optional): Container name. If omitted, returns the first matching container log for the pod.
+- pattern (optional): Regex pattern to filter log lines (grep-style filtering)
+- head (optional): Return only first N lines. Default: %d lines if tail is not specified
+- tail (optional): Return only last N lines
+- apply_tail_first (optional): If both head and tail are set and apply_tail_first is true,
+apply tail before head. Default: false
 
-Searches container logs collected from /var/log/pods/. Returns matching log lines
-with the log file path.
+Reads container logs collected from the sosreport for the specified pod. Returns
+log lines with the log file path.
 
 Examples:
-- pattern='ERROR.*', pod_filter='ovnkube-node'
-- pattern='timeout|timed out', pod_filter='ovn'
-- pattern='failed to start'`, defaultResultLimit),
-		}, s.SearchPodLogs)
+- namespace='openshift-ovn-kubernetes', name='ovnkube-node-abc'
+- namespace='openshift-ovn-kubernetes', name='ovnkube-node-abc', container='ovnkube-controller'
+- namespace='openshift-ovn-kubernetes', name='ovnkube-node-abc', pattern='ERROR.*'`, DefaultMaxLines),
+		}, s.GetPodLogs)
 }
 
 // ListPlugins lists plugins with command counts
@@ -142,7 +150,10 @@ func (s *MCPServer) ListCommands(ctx context.Context, req *mcp.CallToolRequest, 
 
 // SearchCommands searches for commands across all plugins
 func (s *MCPServer) SearchCommands(ctx context.Context, req *mcp.CallToolRequest, in types.SearchCommandsParams) (*mcp.CallToolResult, types.SearchCommandsResult, error) {
-	result, err := searchCommands(in.SosreportPath, in.Pattern, in.MaxResults)
+	if in.Pattern == "" {
+		return nil, types.SearchCommandsResult{}, fmt.Errorf("pattern is required")
+	}
+	result, err := searchCommands(in.SosreportPath, in.PatternParams, in.MaxResults)
 	if err != nil {
 		return nil, types.SearchCommandsResult{}, err
 	}
@@ -151,18 +162,18 @@ func (s *MCPServer) SearchCommands(ctx context.Context, req *mcp.CallToolRequest
 
 // GetCommand retrieves command output by filepath
 func (s *MCPServer) GetCommand(ctx context.Context, req *mcp.CallToolRequest, in types.GetCommandParams) (*mcp.CallToolResult, types.GetCommandResult, error) {
-	output, err := getCommandOutput(in.SosreportPath, in.Filepath, in.Pattern, in.MaxLines)
+	output, err := getCommandOutput(in.SosreportPath, in.Filepath, in.PatternParams, in.HeadTailParams)
 	if err != nil {
 		return nil, types.GetCommandResult{}, err
 	}
 	return nil, types.GetCommandResult{Output: output}, nil
 }
 
-// SearchPodLogs searches pod logs using the manifest
-func (s *MCPServer) SearchPodLogs(ctx context.Context, req *mcp.CallToolRequest, in types.SearchPodLogsParams) (*mcp.CallToolResult, types.SearchPodLogsResult, error) {
-	output, err := searchPodLogs(in.SosreportPath, in.Pattern, in.PodFilter, in.MaxResults)
+// GetPodLogs retrieves pod logs using the manifest
+func (s *MCPServer) GetPodLogs(ctx context.Context, req *mcp.CallToolRequest, in types.GetPodLogsParams) (*mcp.CallToolResult, types.GetPodLogsResult, error) {
+	output, err := getPodLogs(in.SosreportPath, in.Namespace, in.Name, in.Container, in.PatternParams, in.HeadTailParams)
 	if err != nil {
-		return nil, types.SearchPodLogsResult{}, err
+		return nil, types.GetPodLogsResult{}, err
 	}
-	return nil, types.SearchPodLogsResult{Output: output}, nil
+	return nil, types.GetPodLogsResult{Output: output}, nil
 }

--- a/pkg/sosreport/mcp/testdata/sosreport/sos_reports/manifest.json
+++ b/pkg/sosreport/mcp/testdata/sosreport/sos_reports/manifest.json
@@ -30,7 +30,9 @@
           "files": [
             {
               "files_copied": [
-                "host/var/log/pods/openshift-ovn-kubernetes_ovnkube-node-abc/ovnkube-node/0.log"
+                "host/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_ovnkube-controller-deadbeef01.log",
+                "host/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_northd-cafebabe02.log",
+                "host/var/log/containers/ovnkube-control-plane-xyz_openshift-ovn-kubernetes_ovnkube-cluster-manager-feedface03.log"
               ]
             }
           ]

--- a/pkg/sosreport/mcp/testdata/sosreport/var/log/containers/ovnkube-control-plane-xyz_openshift-ovn-kubernetes_ovnkube-cluster-manager-feedface03.log
+++ b/pkg/sosreport/mcp/testdata/sosreport/var/log/containers/ovnkube-control-plane-xyz_openshift-ovn-kubernetes_ovnkube-cluster-manager-feedface03.log
@@ -1,0 +1,2 @@
+2025-10-29T10:00:00.123456789Z stdout F I1029 10:00:00.123456       1 ovnkube.go:123] Starting ovnkube-cluster-manager
+2025-10-29T10:00:02.345678901Z stderr F E1029 10:00:02.345678       1 ovnkube.go:789] ERROR: Cluster manager failed cluster sync

--- a/pkg/sosreport/mcp/testdata/sosreport/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_northd-cafebabe02.log
+++ b/pkg/sosreport/mcp/testdata/sosreport/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_northd-cafebabe02.log
@@ -1,0 +1,2 @@
+2025-10-29T10:00:00.123456789Z stdout F I1029 10:00:00.123456       1 northd.go:10] Starting northd container
+2025-10-29T10:00:01.234567890Z stderr F E1029 10:00:01.234567       1 northd.go:20] ERROR: northd sync failed

--- a/pkg/sosreport/mcp/testdata/sosreport/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_ovnkube-controller-deadbeef01.log
+++ b/pkg/sosreport/mcp/testdata/sosreport/var/log/containers/ovnkube-node-abc_openshift-ovn-kubernetes_ovnkube-controller-deadbeef01.log
@@ -1,4 +1,4 @@
-2025-10-29T10:00:00.123456789Z stdout F I1029 10:00:00.123456       1 ovnkube.go:123] Starting ovnkube-node
+2025-10-29T10:00:00.123456789Z stdout F I1029 10:00:00.123456       1 ovnkube.go:123] Starting ovnkube-controller
 2025-10-29T10:00:01.234567890Z stdout F I1029 10:00:01.234567       1 ovnkube.go:456] Initialized OVN connection
 2025-10-29T10:00:02.345678901Z stderr F E1029 10:00:02.345678       1 ovnkube.go:789] ERROR: Failed to connect to ovn-controller
 2025-10-29T10:00:03.456789012Z stdout F I1029 10:00:03.456789       1 ovnkube.go:890] Retrying connection

--- a/pkg/sosreport/mcp/utils.go
+++ b/pkg/sosreport/mcp/utils.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -40,9 +39,8 @@ func validateRelativePath(relPath string) error {
 	return nil
 }
 
-// readWithLimit reads from a reader with a line limit
-func readWithLimit(reader io.Reader, pattern *regexp.Regexp, maxLines int) (string, error) {
-	var result strings.Builder
+// readLines reads all lines from a reader using a large scanner buffer for long sos lines.
+func readLines(reader io.Reader) ([]string, error) {
 	scanner := bufio.NewScanner(reader)
 
 	// Increase buffer size for long lines
@@ -51,24 +49,14 @@ func readWithLimit(reader io.Reader, pattern *regexp.Regexp, maxLines int) (stri
 	// the maximum size - 1M
 	scanner.Buffer(buf, 1024*1024)
 
-	lineCount := 0
+	var lines []string
 	for scanner.Scan() {
-		if pattern == nil || pattern.MatchString(scanner.Text()) {
-			result.WriteString(scanner.Text())
-			result.WriteString("\n")
-			lineCount++
-		}
-
-		if maxLines > 0 && lineCount >= maxLines {
-			fmt.Fprintf(&result, "\n... (output truncated at %d lines)\n", maxLines)
-			break
-		}
-
+		lines = append(lines, scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return result.String(), nil
+	return lines, nil
 }

--- a/pkg/sosreport/mcp/utils_test.go
+++ b/pkg/sosreport/mcp/utils_test.go
@@ -2,14 +2,11 @@ package sosreport
 
 import (
 	"os"
-	"regexp"
-	"strings"
 	"testing"
 )
 
-func TestReadWithLimit(t *testing.T) {
-	// Create a temporary test file
-	tmpfile, err := os.CreateTemp("", "test-readwithlimit-*.txt")
+func TestReadLines(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "test-readlines-*.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -20,7 +17,6 @@ func TestReadWithLimit(t *testing.T) {
 		}
 	}()
 
-	// Write test content
 	testContent := `line 1: ERROR occurred
 line 2: INFO message
 line 3: ERROR again
@@ -41,50 +37,16 @@ line 10: DEBUG more
 	}
 
 	tests := []struct {
-		name        string
-		pattern     string
-		maxLines    int
-		wantLines   int
-		wantPattern string
-		wantTrunc   bool
+		name      string
+		wantLines int
+		wantFirst string
+		wantLast  string
 	}{
 		{
-			name:      "no pattern, no limit",
-			pattern:   "",
-			maxLines:  0,
+			name:      "reads all lines",
 			wantLines: 10,
-			wantTrunc: false,
-		},
-		{
-			name:      "no pattern, with limit",
-			pattern:   "",
-			maxLines:  5,
-			wantLines: 5,
-			wantTrunc: true,
-		},
-		{
-			name:        "with pattern, no limit",
-			pattern:     "ERROR",
-			maxLines:    0,
-			wantLines:   5,
-			wantPattern: "ERROR",
-			wantTrunc:   false,
-		},
-		{
-			name:        "with pattern, with limit",
-			pattern:     "ERROR",
-			maxLines:    3,
-			wantLines:   3,
-			wantPattern: "ERROR",
-			wantTrunc:   true,
-		},
-		{
-			name:        "pattern with no matches returns empty",
-			pattern:     "NOTFOUND",
-			maxLines:    0,
-			wantLines:   0,
-			wantPattern: "NOTFOUND",
-			wantTrunc:   false,
+			wantFirst: "line 1: ERROR occurred",
+			wantLast:  "line 10: DEBUG more",
 		},
 	}
 
@@ -101,52 +63,22 @@ line 10: DEBUG more
 				}
 			}()
 
-			var searchPattern *regexp.Regexp
-			if tt.pattern != "" {
-				searchPattern = regexp.MustCompile(tt.pattern)
-			}
-
-			result, err := readWithLimit(file, searchPattern, tt.maxLines)
+			lines, err := readLines(file)
 			if err != nil {
-				t.Errorf("readWithLimit() unexpected error = %v", err)
+				t.Errorf("readLines() unexpected error = %v", err)
 				return
 			}
 
-			// Count lines (excluding truncation message and empty lines)
-			lines := strings.Split(result, "\n")
-			actualLines := 0
-			for _, line := range lines {
-				if line != "" && !strings.Contains(line, "output truncated") && !strings.HasPrefix(line, "...") {
-					actualLines++
+			if len(lines) != tt.wantLines {
+				t.Errorf("readLines() got %d lines, want %d", len(lines), tt.wantLines)
+			}
+			if len(lines) > 0 {
+				if lines[0] != tt.wantFirst {
+					t.Errorf("readLines() first line = %q, want %q", lines[0], tt.wantFirst)
 				}
-			}
-
-			// If wantLines is 0, we expect empty string
-			if tt.wantLines == 0 && result != "" {
-				t.Errorf("readWithLimit() expected empty result but got %q", result)
-				return
-			}
-
-			if tt.wantLines > 0 && actualLines != tt.wantLines {
-				t.Errorf("readWithLimit() got %d lines, want %d lines. Result:\n%s", actualLines, tt.wantLines, result)
-			}
-
-			// Check if all lines match the pattern (if pattern is specified)
-			if tt.wantPattern != "" && tt.wantLines > 0 {
-				for _, line := range lines {
-					if line != "" && !strings.Contains(line, "output truncated") && !strings.Contains(line, tt.wantPattern) {
-						t.Errorf("readWithLimit() line %q does not contain pattern %q", line, tt.wantPattern)
-					}
+				if lines[len(lines)-1] != tt.wantLast {
+					t.Errorf("readLines() last line = %q, want %q", lines[len(lines)-1], tt.wantLast)
 				}
-			}
-
-			// Check for truncation message
-			hasTruncMsg := strings.Contains(result, "output truncated")
-			if tt.wantTrunc && !hasTruncMsg {
-				t.Errorf("readWithLimit() expected truncation message but didn't find it")
-			}
-			if !tt.wantTrunc && hasTruncMsg {
-				t.Errorf("readWithLimit() unexpected truncation message")
 			}
 		})
 	}

--- a/pkg/sosreport/types/command.go
+++ b/pkg/sosreport/types/command.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/pattern"
+)
+
 // ListCommandsParams are the parameters for sos-list-commands
 type ListCommandsParams struct {
 	SosreportPath string `json:"sosreport_path"`
@@ -22,8 +27,8 @@ type CommandSummary struct {
 // SearchCommandsParams are the parameters for sos-search-commands
 type SearchCommandsParams struct {
 	SosreportPath string `json:"sosreport_path"`
-	Pattern       string `json:"pattern"`
-	MaxResults    int    `json:"max_results,omitempty"`
+	pattern.PatternParams
+	MaxResults int `json:"max_results,omitempty"`
 }
 
 // SearchCommandsResult returns commands matching the pattern
@@ -43,8 +48,8 @@ type CommandMatch struct {
 type GetCommandParams struct {
 	SosreportPath string `json:"sosreport_path"`
 	Filepath      string `json:"filepath"`
-	Pattern       string `json:"pattern,omitempty"`
-	MaxLines      int    `json:"max_lines,omitempty"`
+	pattern.PatternParams
+	headtail.HeadTailParams
 }
 
 // GetCommandResult returns the command output

--- a/pkg/sosreport/types/logs.go
+++ b/pkg/sosreport/types/logs.go
@@ -1,14 +1,21 @@
 package types
 
-// SearchPodLogsParams are the parameters for sos-search-pod-logs
-type SearchPodLogsParams struct {
+import (
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/headtail"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils/pattern"
+)
+
+// GetPodLogsParams are the parameters for sos-get-pod-logs
+type GetPodLogsParams struct {
 	SosreportPath string `json:"sosreport_path"`
-	Pattern       string `json:"pattern"`
-	PodFilter     string `json:"pod_filter,omitempty"`
-	MaxResults    int    `json:"max_results,omitempty"`
+	Name          string `json:"name"`
+	Namespace     string `json:"namespace"`
+	Container     string `json:"container,omitempty"`
+	pattern.PatternParams
+	headtail.HeadTailParams
 }
 
-// SearchPodLogsResult returns matching pod log lines
-type SearchPodLogsResult struct {
+// GetPodLogsResult returns matching pod log lines
+type GetPodLogsResult struct {
 	Output string `json:"output"`
 }

--- a/test/e2e/sosreport_test.go
+++ b/test/e2e/sosreport_test.go
@@ -22,7 +22,7 @@ var _ = Describe("[offline] Sosreport Tools", func() {
 		sosListCommandsToolName   = "sos-list-commands"
 		sosSearchCommandsToolName = "sos-search-commands"
 		sosGetCommandToolName     = "sos-get-command"
-		sosSearchPodLogsToolName  = "sos-search-pod-logs"
+		sosGetPodLogsToolName     = "sos-get-pod-logs"
 	)
 
 	DescribeTable("List Plugins",
@@ -203,53 +203,132 @@ var _ = Describe("[offline] Sosreport Tools", func() {
 		}
 	})
 
-	DescribeTable("Search Pod Logs",
-		func(pattern string, podFilter string, expectedSubstrings []string) {
+	It("Get Command should apply head and tail limits", func() {
+		By("Calling sos-get-command with head=2")
+		headOutput, err := mcpInspector.
+			MethodCall(sosGetCommandToolName, map[string]any{
+				"sosreport_path": testdataSosreportPath,
+				"filepath":       "sos_commands/networking/ip_addr_show",
+				"head":           2,
+			}).Execute()
+		Expect(err).NotTo(HaveOccurred())
+
+		headResult := utils.UnmarshalCallToolResult[sostypes.GetCommandResult](headOutput)
+		headLines := strings.Split(strings.TrimSpace(headResult.Output), "\n")
+		Expect(headLines).To(HaveLen(2))
+
+		By("Calling sos-get-command with tail=2")
+		tailOutput, err := mcpInspector.
+			MethodCall(sosGetCommandToolName, map[string]any{
+				"sosreport_path": testdataSosreportPath,
+				"filepath":       "sos_commands/networking/ip_addr_show",
+				"tail":           2,
+			}).Execute()
+		Expect(err).NotTo(HaveOccurred())
+
+		tailResult := utils.UnmarshalCallToolResult[sostypes.GetCommandResult](tailOutput)
+		tailLines := strings.Split(strings.TrimSpace(tailResult.Output), "\n")
+		Expect(tailLines).To(HaveLen(2))
+		Expect(tailResult.Output).NotTo(Equal(headResult.Output))
+	})
+
+	DescribeTable("Get Pod Logs",
+		func(pattern string, namespace string, name string, container string, expectedSubstrings []string, unexpectedSubstrings []string) {
 			params := map[string]any{
 				"sosreport_path": testdataSosreportPath,
-				"pattern":        pattern,
+				"namespace":      namespace,
+				"name":           name,
 			}
-			if podFilter != "" {
-				params["pod_filter"] = podFilter
+			if pattern != "" {
+				params["pattern"] = pattern
+			}
+			if container != "" {
+				params["container"] = container
 			}
 
-			By("Calling sos-search-pod-logs")
+			By("Calling sos-get-pod-logs")
 			output, err := mcpInspector.
-				MethodCall(sosSearchPodLogsToolName, params).Execute()
+				MethodCall(sosGetPodLogsToolName, params).Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(BeEmpty())
 
 			By("Checking the result")
-			result := utils.UnmarshalCallToolResult[sostypes.SearchPodLogsResult](output)
+			result := utils.UnmarshalCallToolResult[sostypes.GetPodLogsResult](output)
 
-			// Verify all expected substrings are present
 			for _, expected := range expectedSubstrings {
 				Expect(result.Output).To(ContainSubstring(expected))
 			}
+			for _, unexpected := range unexpectedSubstrings {
+				Expect(result.Output).NotTo(ContainSubstring(unexpected))
+			}
 		},
-		Entry("should search for ERROR pattern in pod logs",
-			"ERROR",
+		Entry("should get first container logs when container omitted",
 			"",
+			"openshift-ovn-kubernetes",
+			"ovnkube-node-abc",
+			"",
+			[]string{
+				"Starting ovnkube-controller",
+				"Successfully connected to ovn-controller",
+			},
+			[]string{"northd"},
+		),
+		Entry("should get specific container logs",
+			"",
+			"openshift-ovn-kubernetes",
+			"ovnkube-node-abc",
+			"northd",
+			[]string{
+				"Starting northd container",
+			},
+			[]string{"Starting ovnkube-controller"},
+		),
+		Entry("should filter pod logs by ERROR pattern",
+			"ERROR",
+			"openshift-ovn-kubernetes",
+			"ovnkube-node-abc",
+			"ovnkube-controller",
 			[]string{
 				"ERROR",
 				"Failed to connect to ovn-controller",
-				"ovnkube-node",
 			},
+			nil,
 		),
-		Entry("should search pod logs with pod filter",
-			"ovnkube",
-			"ovnkube-node",
-			[]string{
-				"ovnkube-node",
-				"Starting ovnkube-node",
-			},
-		),
-		Entry("should search for successful connection in pod logs",
+		Entry("should filter pod logs by successful connection",
 			"Successfully connected",
+			"openshift-ovn-kubernetes",
+			"ovnkube-node-abc",
 			"",
 			[]string{
 				"Successfully connected to ovn-controller",
 			},
+			nil,
 		),
 	)
+
+	It("Get Pod Logs should require name", func() {
+		By("Calling sos-get-pod-logs without name")
+		output, err := mcpInspector.
+			MethodCall(sosGetPodLogsToolName, map[string]any{
+				"sosreport_path": testdataSosreportPath,
+				"namespace":      "openshift-ovn-kubernetes",
+			}).Execute()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(output)).To(ContainSubstring(`"isError": true`))
+		Expect(string(output)).To(ContainSubstring(`missing properties`))
+		Expect(string(output)).To(ContainSubstring(`name`))
+	})
+
+	It("Get Pod Logs should require namespace", func() {
+		By("Calling sos-get-pod-logs without namespace")
+		output, err := mcpInspector.
+			MethodCall(sosGetPodLogsToolName, map[string]any{
+				"sosreport_path": testdataSosreportPath,
+				"name":           "ovnkube-node-abc",
+			}).Execute()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(output)).To(ContainSubstring(`"isError": true`))
+		Expect(string(output)).To(ContainSubstring(`missing properties`))
+		Expect(string(output)).To(ContainSubstring(`namespace`))
+	})
 })


### PR DESCRIPTION
Fixes: #88 

Bring sosreport content tools onto PatternParams/HeadTailParams, and reshape the pod log tool as sos-get-pod-logs with namespace, name, and optional container—matching kubernetes and must-gather rather than a search-oriented pod_filter interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced `sos-search-pod-logs` with `sos-get-pod-logs` for retrieving logs from a specific Kubernetes pod/namespace, optionally narrowed to a container, including compressed log files.
  * Added pattern filtering and head/tail trimming for both command output and pod logs (including tail-first option).

* **Bug Fixes**
  * Improved handling and clarity for missing pod details, invalid/empty patterns, unavailable logs, and unmatched results.

* **Documentation**
  * Updated the Offline Mode tools table to reflect `sos-get-pod-logs`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->