### PR TITLE
bump nvm version to 0.40.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ deploy-kind-ovnk:
 undeploy-kind-ovnk:
 	@$(GIT_ROOT)/hack/undeploy-kind-ovnk.sh
 
-NVM_VERSION := 0.40.4
+NVM_VERSION := 0.40.6
 NODE_VERSION := 26.5.0
 NPM_VERSION := 12.0.1
 GINKGO_VERSION := v2.32.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node Version Manager used for end-to-end test execution to version 0.40.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->