### PR TITLE
ovs: add unit tests for consolidated tool action validation

### DIFF
--- a/pkg/ovs/mcp/commands.go
+++ b/pkg/ovs/mcp/commands.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	ovstypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovs/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/utils"
 )
 
@@ -55,4 +56,34 @@ func validateConntrackParams(params []string) error {
 	}
 
 	return nil
+}
+
+// validateVsctlAction validates that the action is a supported ovs-vsctl subcommand.
+func validateVsctlAction(action string) error {
+	switch ovstypes.VsctlAction(action) {
+	case ovstypes.VsctlShow, ovstypes.VsctlListBr, ovstypes.VsctlListPorts, ovstypes.VsctlListIfaces:
+		return nil
+	default:
+		return fmt.Errorf(`invalid action %q: must be one of "show", "list-br", "list-ports", "list-ifaces"`, action)
+	}
+}
+
+// validateOfctlAction validates that the action is a supported ovs-ofctl subcommand.
+func validateOfctlAction(action string) error {
+	switch ovstypes.OfctlAction(action) {
+	case ovstypes.OfctlDumpFlows:
+		return nil
+	default:
+		return fmt.Errorf(`invalid action %q: must be one of "dump-flows"`, action)
+	}
+}
+
+// validateAppctlAction validates that the action is a supported ovs-appctl subcommand.
+func validateAppctlAction(action string) error {
+	switch ovstypes.AppctlAction(action) {
+	case ovstypes.AppctlDumpConntrack, ovstypes.AppctlOfprotoTrace:
+		return nil
+	default:
+		return fmt.Errorf(`invalid action %q: must be one of "dpctl/dump-conntrack", "ofproto/trace"`, action)
+	}
 }

--- a/pkg/ovs/mcp/commands_test.go
+++ b/pkg/ovs/mcp/commands_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"testing"
+
+	ovstypes "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovs/types"
 )
 
 func TestValidateBridgeName(t *testing.T) {
@@ -338,6 +340,260 @@ func TestValidateConntrackParams(t *testing.T) {
 			err := validateConntrackParams(tt.params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateConntrackParams() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateVsctlAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		wantErr bool
+	}{
+		{
+			name:    "valid show",
+			action:  string(ovstypes.VsctlShow),
+			wantErr: false,
+		},
+		{
+			name:    "valid list-br",
+			action:  string(ovstypes.VsctlListBr),
+			wantErr: false,
+		},
+		{
+			name:    "valid list-ports",
+			action:  string(ovstypes.VsctlListPorts),
+			wantErr: false,
+		},
+		{
+			name:    "valid list-ifaces",
+			action:  string(ovstypes.VsctlListIfaces),
+			wantErr: false,
+		},
+		{
+			name:    "empty action returns error",
+			action:  "",
+			wantErr: true,
+		},
+		{
+			name:    "unknown action returns error",
+			action:  "bogus",
+			wantErr: true,
+		},
+		{
+			name:    "typo of show returns error",
+			action:  "shoow",
+			wantErr: true,
+		},
+		{
+			name:    "uppercase show returns error",
+			action:  "SHOW",
+			wantErr: true,
+		},
+		{
+			name:    "titlecase show returns error",
+			action:  "Show",
+			wantErr: true,
+		},
+		{
+			name:    "trailing space returns error",
+			action:  "show ",
+			wantErr: true,
+		},
+		{
+			name:    "leading space returns error",
+			action:  " show",
+			wantErr: true,
+		},
+		{
+			name:    "ofctl action leaks in returns error",
+			action:  "dump-flows",
+			wantErr: true,
+		},
+		{
+			name:    "appctl action leaks in returns error",
+			action:  "dpctl/dump-conntrack",
+			wantErr: true,
+		},
+		{
+			name:    "appctl trace leaks in returns error",
+			action:  "ofproto/trace",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVsctlAction(tt.action)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateVsctlAction() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOfctlAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		wantErr bool
+	}{
+		{
+			name:    "valid dump-flows",
+			action:  string(ovstypes.OfctlDumpFlows),
+			wantErr: false,
+		},
+		{
+			name:    "empty action returns error",
+			action:  "",
+			wantErr: true,
+		},
+		{
+			name:    "unknown action returns error",
+			action:  "dump-groups",
+			wantErr: true,
+		},
+		{
+			name:    "typo returns error",
+			action:  "dumpflows",
+			wantErr: true,
+		},
+		{
+			name:    "uppercase returns error",
+			action:  "DUMP-FLOWS",
+			wantErr: true,
+		},
+		{
+			name:    "titlecase returns error",
+			action:  "Dump-Flows",
+			wantErr: true,
+		},
+		{
+			name:    "trailing space returns error",
+			action:  "dump-flows ",
+			wantErr: true,
+		},
+		{
+			name:    "leading space returns error",
+			action:  " dump-flows",
+			wantErr: true,
+		},
+		{
+			name:    "vsctl action leaks in returns error",
+			action:  "show",
+			wantErr: true,
+		},
+		{
+			name:    "vsctl list-br leaks in returns error",
+			action:  "list-br",
+			wantErr: true,
+		},
+		{
+			name:    "appctl action leaks in returns error",
+			action:  "ofproto/trace",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOfctlAction(tt.action)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateOfctlAction() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAppctlAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		wantErr bool
+	}{
+		{
+			name:    "valid dpctl/dump-conntrack",
+			action:  string(ovstypes.AppctlDumpConntrack),
+			wantErr: false,
+		},
+		{
+			name:    "valid ofproto/trace",
+			action:  string(ovstypes.AppctlOfprotoTrace),
+			wantErr: false,
+		},
+		{
+			name:    "empty action returns error",
+			action:  "",
+			wantErr: true,
+		},
+		{
+			name:    "unknown action returns error",
+			action:  "foo/bar",
+			wantErr: true,
+		},
+		{
+			name:    "missing slash in ofproto trace returns error",
+			action:  "ofprototrace",
+			wantErr: true,
+		},
+		{
+			name:    "missing slash in dpctl dump conntrack returns error",
+			action:  "dpctldumpconntrack",
+			wantErr: true,
+		},
+		{
+			name:    "backslash instead of slash returns error",
+			action:  `ofproto\trace`,
+			wantErr: true,
+		},
+		{
+			name:    "uppercase returns error",
+			action:  "OFPROTO/TRACE",
+			wantErr: true,
+		},
+		{
+			name:    "titlecase returns error",
+			action:  "Ofproto/Trace",
+			wantErr: true,
+		},
+		{
+			name:    "trailing space returns error",
+			action:  "ofproto/trace ",
+			wantErr: true,
+		},
+		{
+			name:    "leading space returns error",
+			action:  " ofproto/trace",
+			wantErr: true,
+		},
+		{
+			name:    "vsctl action leaks in returns error",
+			action:  "show",
+			wantErr: true,
+		},
+		{
+			name:    "ofctl action leaks in returns error",
+			action:  "dump-flows",
+			wantErr: true,
+		},
+		{
+			name:    "partial match dpctl returns error",
+			action:  "dpctl",
+			wantErr: true,
+		},
+		{
+			name:    "partial match trace returns error",
+			action:  "trace",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAppctlAction(tt.action)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAppctlAction() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/ovs/mcp/mcp.go
+++ b/pkg/ovs/mcp/mcp.go
@@ -152,6 +152,10 @@ Example output (action='ofproto/trace'):
 func (s *MCPServer) Vsctl(ctx context.Context, req *mcp.CallToolRequest,
 	in ovstypes.VsctlParams) (*mcp.CallToolResult, ovstypes.VsctlResult, error) {
 
+	if err := validateVsctlAction(in.Action); err != nil {
+		return nil, ovstypes.VsctlResult{}, err
+	}
+
 	switch ovstypes.VsctlAction(in.Action) {
 	case ovstypes.VsctlShow:
 		output, err := s.show(ctx, in.Namespace, in.Name, in.HeadTailParams)
@@ -179,6 +183,10 @@ func (s *MCPServer) Vsctl(ctx context.Context, req *mcp.CallToolRequest,
 func (s *MCPServer) Ofctl(ctx context.Context, req *mcp.CallToolRequest,
 	in ovstypes.OfctlParams) (*mcp.CallToolResult, ovstypes.OfctlResult, error) {
 
+	if err := validateOfctlAction(in.Action); err != nil {
+		return nil, ovstypes.OfctlResult{}, err
+	}
+
 	switch ovstypes.OfctlAction(in.Action) {
 	case ovstypes.OfctlDumpFlows:
 		flows, err := s.dumpFlows(ctx, in.Namespace, in.Name, in.Bridge, in.PatternParams, in.HeadTailParams)
@@ -193,6 +201,10 @@ func (s *MCPServer) Ofctl(ctx context.Context, req *mcp.CallToolRequest,
 // required "action" parameter.
 func (s *MCPServer) Appctl(ctx context.Context, req *mcp.CallToolRequest,
 	in ovstypes.AppctlParams) (*mcp.CallToolResult, ovstypes.AppctlResult, error) {
+
+	if err := validateAppctlAction(in.Action); err != nil {
+		return nil, ovstypes.AppctlResult{}, err
+	}
 
 	switch ovstypes.AppctlAction(in.Action) {
 	case ovstypes.AppctlDumpConntrack:


### PR DESCRIPTION
Follow-up to #69 to add the tests for validating the inputs for the ovs tools. [(comment).](https://github.com/ovn-kubernetes/ovn-kubernetes-mcp/pull/69#pullrequestreview-4735778755)

## Summary

Adds unit tests for the `action` field validation of the three consolidated OVS tools introduced in #69:

- `TestValidateVsctlAction` — covers `show`, `list-br`, `list-ports`, `list-ifaces`
- `TestValidateOfctlAction` — covers `dump-flows`
- `TestValidateAppctlAction` — covers `dpctl/dump-conntrack`, `ofproto/trace`

To make the action validation unit-testable, the inline switch-default logic in each dispatcher is taken out into a small helper (`validateVsctlAction`, `validateOfctlAction`, `validateAppctlAction`).

## Test plan

- [x] `go build ./...`
- [x] `go test -v -count=1 -race ./pkg/ovs/mcp/...` — all pass
- [x] MCP Inspector tests:  valid `action` returns success, invalid `action` returns the validator's error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for supported actions across OVS control commands.
  * Invalid, empty, mixed-case, whitespace-variant, and cross-command actions are now rejected with clear errors.
  * Prevented unsupported actions from being dispatched.

* **Tests**
  * Added comprehensive coverage for valid and invalid action inputs across all command types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->