### PR TITLE
Add --version flag and CHANGELOG.md for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## v0.1.0 — Initial Release
+
+The first release of the OVN-Kubernetes MCP Server — a Model Context Protocol server
+for troubleshooting OVN-Kubernetes clusters with AI assistants.
+
+### Highlights
+
+- **Three operating modes**: `live-cluster` for real-time cluster debugging,
+  `offline` for analyzing sosreports and must-gather archives, and `dual` for both.
+  See the [User Guide](docs/user-guide.md) for full details.
+
+- **Two transport modes**: `stdio` for direct IDE integration (Cursor, Claude, etc.)
+  and `http` (Streamable HTTP) for remote/containerized deployments.
+  See [connection setup](README.md#how-to-connect-to-the-mcp-server).
+
+- **Live cluster tools**:
+  - **[Kubernetes](docs/kubernetes.md)**: pod logs, resource get/list with jsonpath support.
+  - **[OVN](docs/ovn.md)**: show, get, lflow-list, trace across Northbound/Southbound databases.
+  - **[OVS](docs/ovs.md)**: bridge/port/interface listing, OpenFlow dump, conntrack dump, ofproto-trace.
+  - **[Kernel](docs/kernel.md)**: conntrack, iptables, nft, ip route/device inspection via debug pods.
+  - **[Network tools](docs/network-tools.md)**: tcpdump packet capture and pwru eBPF kernel packet tracing.
+
+- **Offline analysis tools**:
+  - **[sosreport](docs/sosreport.md)**: plugin listing, command search, pod log search.
+  - **[must-gather](docs/must-gather.md)**: resource get/list, pod logs, OVN-K info, OVN database queries
+    via ovsdb-tool.
+
+- **[Kubernetes deployment](README.md#kubernetes-deployment)**: Dockerfile, kustomize manifests, RBAC, NetworkPolicy,
+  and Service for running the server in-cluster with ServiceAccount credentials.
+
+- **Tool timeout enforcement**: configurable per-tool timeout (default 120s) applied
+  at the protocol middleware layer.
+
+- **[Selective tool exposure](README.md#selectively-exposing-tools)**: `--disable-categories` and `--disable-tools` flags to
+  hide tools/categories from clients without code changes.
+
+- **E2E test suite**: Ginkgo-based end-to-end tests covering live-cluster, offline,
+  and dual modes with CI integration.

--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"maps"
 	"net"
@@ -24,6 +25,7 @@ import (
 	ovnmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovn/mcp"
 	ovsmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/ovs/mcp"
 	sosreportmcp "github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/sosreport/mcp"
+	"github.com/ovn-kubernetes/ovn-kubernetes-mcp/pkg/version"
 )
 
 const defaultNetshootImage = "nicolaka/netshoot:v0.15"
@@ -185,8 +187,10 @@ func parseFlags() *MCPServerConfig {
 		timeoutSeconds     int
 		disabledCategories string
 		disabledTools      string
+		showVersion        bool
 	)
 
+	flag.BoolVar(&showVersion, "version", false, "Print the version and exit")
 	flag.StringVar(&cfg.Mode, "mode", "live-cluster", "Mode of debugging: live-cluster or offline or dual")
 	flag.StringVar(&cfg.Transport, "transport", "stdio", "Transport to use: stdio or http")
 	flag.StringVar(&cfg.Host, "host", "localhost", "Host to bind to (use 0.0.0.0 for container/cluster)")
@@ -201,6 +205,11 @@ func parseFlags() *MCPServerConfig {
 	flag.StringVar(&disabledTools, "disable-tools", "",
 		"Comma-separated tool names to hide from clients (e.g. tcpdump,pwru)")
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println(version.Print())
+		os.Exit(0)
+	}
 
 	// Convert timeout to duration and apply limits
 	if timeoutSeconds < 0 {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import "fmt"
+
+const (
+	Version = "0.1.0"
+)
+
+func Print() string {
+	return fmt.Sprintf("ovn-kubernetes-mcp-server version %s", Version)
+}


### PR DESCRIPTION
Introduce a pkg/version package with a hardcoded version string and wire a --version CLI flag that prints it and exits. Add CHANGELOG.md documenting the highlights of the initial release.

```
 ./_output/ovnk-mcp-server --version
ovn-kubernetes-mcp-server version 0.1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to display the server version and exit.
  * Introduced version information for the initial 0.1.0 release.

* **Documentation**
  * Added a changelog covering the initial release, operating and transport modes, available tools, deployment options, configuration flags, and end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->