### PR TITLE
feat(kubernetes): add resource-describe tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Available when running with `--mode live-cluster` or `--mode dual` (and with a v
 | **kubernetes** | `pod-logs` | Get container logs from a pod in the Kubernetes cluster. |
 | | `resource-get` | Get a specific Kubernetes resource by name. |
 | | `resource-list` | List Kubernetes resources of a specific kind. |
+| | `resource-describe` | Describe a specific Kubernetes resource by name, similar to 'kubectl describe'. |
 | **ovn** | `ovn-show` | Display a comprehensive overview of OVN configuration from either the Northbound or Southbound database. |
 | | `ovn-get` | Query records from an OVN database table with flexible filtering. |
 | | `ovn-lflow-list` | List logical flows from the OVN Southbound database. |

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -9,6 +9,7 @@ See also: [User guide](user-guide.md) (including [common parameters](user-guide.
 | [`pod-logs`](#pod-logs) | Get container logs from a pod in the Kubernetes cluster |
 | [`resource-get`](#resource-get) | Get a specific Kubernetes resource by name |
 | [`resource-list`](#resource-list) | List Kubernetes resources of a specific kind |
+| [`resource-describe`](#resource-describe) | Describe a specific Kubernetes resource by name, similar to `kubectl describe` |
 
 ---
 
@@ -193,4 +194,50 @@ Lists resources in a namespace or across all namespaces. Supports filtering by l
   "namespace": "default",
   "output_type": "jsonpath='{.items[*].metadata.name}'"
 }
+```
+
+---
+
+## resource-describe
+
+Retrieves a resource's spec, status, and its related Events, similar to `kubectl describe`. Events explain WHY a resource is in its current state (e.g. scheduling failures, image pull errors, network policy denials, probe failures), which plain `resource-get` output does not show. Use this instead of `resource-get` when troubleshooting why a resource is failing or misbehaving.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `group` | string | no | empty (core resources) | API group of the resource (e.g., `"apps"`, `"networking.k8s.io"`). Empty for core resources |
+| `version` | string | **yes** | — | API version of the resource (e.g., `"v1"`, `"v1beta1"`) |
+| `kind` | string | **yes** | — | Kind of the resource (e.g., `"Pod"`, `"Service"`, `"Deployment"`, `"Node"`) |
+| `name` | string | **yes** | — | Name of the resource to describe |
+| `namespace` | string | no | `"default"` for namespaced resources; empty for cluster-scoped | Namespace of the resource. If omitted, defaults to `"default"` for namespaced resources and empty for cluster-scoped resources |
+
+Returns a text description containing the resource's name, namespace, labels, annotations, spec, status and a table of related Events (type, reason, age, source, message) sorted from oldest to newest.
+
+### Examples
+
+```json
+{"version": "v1", "kind": "Pod", "name": "my-pod"}
+```
+
+```json
+{"version": "v1", "kind": "Pod", "name": "my-pod", "namespace": "default"}
+```
+
+```json
+{
+  "group": "apps",
+  "version": "v1",
+  "kind": "Deployment",
+  "name": "my-deployment",
+  "namespace": "default"
+}
+```
+
+```json
+{"version": "v1", "kind": "Node", "name": "worker-0"}
+```
+
+```json
+{"version": "v1", "kind": "Service", "name": "my-service", "namespace": "default"}
 ```

--- a/pkg/kubernetes/client/describe.go
+++ b/pkg/kubernetes/client/describe.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// DescribeResource fetches a resource by group, version, kind, name and namespace
+// together with the Kubernetes Events associated with it. Unlike GetResource, it
+// also returns the resource's Events so that callers can render a description
+// similar to `kubectl describe`. It works generically for any resource kind
+// (built-in or CRD) since it relies only on the dynamic client and the resource's
+// metadata to correlate events.
+func (c *OVNKMCPServerClientSet) DescribeResource(ctx context.Context, group, version, kind, name, namespace string) (*unstructured.Unstructured, *corev1.EventList, error) {
+	resource, err := c.GetResource(ctx, group, version, kind, name, namespace)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events, err := c.getEventsForObject(ctx, resource)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get events for resource %s with name %s: %w", kind, name, err)
+	}
+
+	return resource, events, nil
+}
+
+// getEventsForObject returns the Events associated with the given object. Objects
+// are matched by UID when available, falling back to namespace/name/kind so that
+// events are still surfaced for objects whose UID was stripped (e.g. by a cache).
+func (c *OVNKMCPServerClientSet) getEventsForObject(ctx context.Context, object *unstructured.Unstructured) (*corev1.EventList, error) {
+	allEvents, err := c.clientSet.CoreV1().Events(object.GetNamespace()).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	matched := &corev1.EventList{}
+	for _, event := range allEvents.Items {
+		if eventMatchesObject(event, object) {
+			matched.Items = append(matched.Items, event)
+		}
+	}
+	return matched, nil
+}
+
+// eventMatchesObject reports whether the event's InvolvedObject reference points
+// at the given object.
+func eventMatchesObject(event corev1.Event, object *unstructured.Unstructured) bool {
+	if object.GetUID() != "" && event.InvolvedObject.UID == object.GetUID() {
+		return true
+	}
+	return event.InvolvedObject.Name == object.GetName() &&
+		event.InvolvedObject.Namespace == object.GetNamespace() &&
+		event.InvolvedObject.Kind == object.GetKind()
+}

--- a/pkg/kubernetes/client/describe_test.go
+++ b/pkg/kubernetes/client/describe_test.go
@@ -1,0 +1,143 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestDescribeResource(t *testing.T) {
+	tests := []struct {
+		testName       string
+		objects        []runtime.Object
+		gvk            schema.GroupVersionKind
+		objectName     string
+		namespace      string
+		expectedErr    bool
+		expectedEvents []string // expected event names, in the order returned
+	}{
+		{
+			testName: "Pod resource returns only events involving it",
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx",
+						Namespace: "default",
+						UID:       "pod-uid",
+						Labels:    map[string]string{"app": "nginx"},
+					},
+				},
+				&corev1.Event{
+					ObjectMeta: metav1.ObjectMeta{Name: "nginx.ev1", Namespace: "default"},
+					InvolvedObject: corev1.ObjectReference{
+						Kind:      "Pod",
+						Name:      "nginx",
+						Namespace: "default",
+						UID:       "pod-uid",
+					},
+				},
+				// Event for a different pod; must not be matched.
+				&corev1.Event{
+					ObjectMeta: metav1.ObjectMeta{Name: "other.ev1", Namespace: "default"},
+					InvolvedObject: corev1.ObjectReference{
+						Kind:      "Pod",
+						Name:      "other-pod",
+						Namespace: "default",
+						UID:       "other-uid",
+					},
+				},
+			},
+			gvk:            schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			objectName:     "nginx",
+			namespace:      "default",
+			expectedEvents: []string{"nginx.ev1"},
+		},
+		{
+			testName: "Resource without matching events returns an empty event list",
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-events",
+						Namespace: "default",
+					},
+				},
+			},
+			gvk:            schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			objectName:     "no-events",
+			namespace:      "default",
+			expectedEvents: []string{},
+		},
+		{
+			testName: "Cluster-scoped resource (Node) matches events by UID across namespaces",
+			objects: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-0",
+						UID:  "node-uid",
+					},
+				},
+				&corev1.Event{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker-0.ev1", Namespace: "default"},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: "Node",
+						Name: "worker-0",
+						UID:  "node-uid",
+					},
+				},
+			},
+			gvk:            schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"},
+			objectName:     "worker-0",
+			namespace:      "",
+			expectedEvents: []string{"worker-0.ev1"},
+		},
+		{
+			testName:    "Resource not found returns an error",
+			objects:     []runtime.Object{},
+			gvk:         schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			objectName:  "missing",
+			namespace:   "default",
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			fakeclient := NewFakeClient(test.objects...)
+			resource, events, err := fakeclient.DescribeResource(context.Background(), test.gvk.Group, test.gvk.Version, test.gvk.Kind, test.objectName, test.namespace)
+			if (err != nil) != test.expectedErr {
+				t.Fatalf("DescribeResource() error = %v, expectedErr = %v", err, test.expectedErr)
+			}
+			if test.expectedErr {
+				return
+			}
+
+			if resource == nil {
+				t.Fatalf("expected a non-nil resource")
+			}
+			if resource.GetName() != test.objectName {
+				t.Errorf("expected resource name %q, got %q", test.objectName, resource.GetName())
+			}
+
+			if events == nil {
+				t.Fatalf("expected a non-nil event list")
+			}
+			gotNames := make([]string, 0, len(events.Items))
+			for _, e := range events.Items {
+				gotNames = append(gotNames, e.Name)
+			}
+			if len(gotNames) != len(test.expectedEvents) {
+				t.Fatalf("expected events %v, got %v", test.expectedEvents, gotNames)
+			}
+			for i, name := range test.expectedEvents {
+				if gotNames[i] != name {
+					t.Errorf("expected events %v, got %v", test.expectedEvents, gotNames)
+					break
+				}
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/mcp/mcp.go
+++ b/pkg/kubernetes/mcp/mcp.go
@@ -136,4 +136,34 @@ Examples:
 - List with detailed info: {"version": "v1", "kind": "Pod", "namespace": "kube-system", "output_type": "wide"}
 - List pod names as JSONPath: {"version": "v1", "kind": "Pod", "namespace": "default", "output_type": "jsonpath='{.items[*].metadata.name}'"}`,
 		}, s.ListResources)
+
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name: "resource-describe",
+			Description: `Describe a specific Kubernetes resource by name, similar to 'kubectl describe'.
+
+Retrieves a resource's spec, status, and its related Events. Events explain WHY a
+resource is in its current state (e.g. scheduling failures, image pull errors,
+network policy denials, probe failures) which plain "get" output does not show.
+Use this instead of resource-get when troubleshooting why a resource is failing
+or misbehaving.
+
+Parameters:
+- group (optional): API group of the resource (e.g., "apps", "networking.k8s.io"). Empty for core resources
+- version (required): API version of the resource (e.g., "v1", "v1beta1")
+- kind (required): Kind of the resource (e.g., "Pod", "Service", "Deployment", "Node")
+- name (required): Name of the resource to describe
+- namespace (optional): Namespace of the resource. If omitted, defaults to "default" for namespaced resources and empty for cluster-scoped resources
+
+Returns a text description containing the resource's name, namespace, labels,
+annotations, spec, status and a table of related Events (type, reason, age,
+source, message) sorted from oldest to newest.
+
+Examples:
+- Describe a pod (defaults to "default" namespace): {"version": "v1", "kind": "Pod", "name": "my-pod"}
+- Describe a pod to debug a crash or scheduling issue: {"version": "v1", "kind": "Pod", "name": "my-pod", "namespace": "default"}
+- Describe a deployment: {"group": "apps", "version": "v1", "kind": "Deployment", "name": "my-deployment", "namespace": "default"}
+- Describe a node (cluster-scoped): {"version": "v1", "kind": "Node", "name": "worker-0"}
+- Describe a service to check endpoint issues: {"version": "v1", "kind": "Service", "name": "my-service", "namespace": "default"}`,
+		}, s.DescribeResource)
 }

--- a/pkg/kubernetes/mcp/resources.go
+++ b/pkg/kubernetes/mcp/resources.go
@@ -127,3 +127,32 @@ func (s *MCPServer) ListResources(ctx context.Context, req *mcp.CallToolRequest,
 
 	return nil, types.ListResourcesResult{Resources: resourcesData}, nil
 }
+
+// DescribeResource describes a resource by group, version, kind, name and namespace,
+// including its spec, status and related events, similar to `kubectl describe`.
+func (s *MCPServer) DescribeResource(ctx context.Context, req *mcp.CallToolRequest, in types.DescribeResourceParams) (*mcp.CallToolResult, types.DescribeResourceResult, error) {
+	// If the version, kind or name is not set, return an error.
+	var err error
+	if in.Version == "" {
+		err = errors.New("version is required")
+	}
+	if in.Kind == "" {
+		err = errors.Join(err, errors.New("kind is required"))
+	}
+	if in.Name == "" {
+		err = errors.Join(err, errors.New("name is required"))
+	}
+	if err != nil {
+		return nil, types.DescribeResourceResult{}, err
+	}
+
+	// Describe the resource by group, version, kind, name and namespace.
+	resource, events, err := s.clientSet.DescribeResource(ctx, in.Group, in.Version, in.Kind, in.Name, in.Namespace)
+	if err != nil {
+		return nil, types.DescribeResourceResult{}, err
+	}
+
+	result := types.DescribeResourceResult{}
+	result.Describe(resource, events)
+	return nil, result, nil
+}

--- a/pkg/kubernetes/types/resources.go
+++ b/pkg/kubernetes/types/resources.go
@@ -1,5 +1,16 @@
 package types
 
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kubectldescribe "k8s.io/kubectl/pkg/describe"
+	yaml "sigs.k8s.io/yaml"
+)
+
 // GetResourceParams is a type that contains the group, version, kind, name and namespace of a resource.
 type GetResourceParams struct {
 	GroupVersionKind
@@ -27,4 +38,85 @@ type ListResourcesParams struct {
 // ListResourcesResult is a type that contains the resource data.
 type ListResourcesResult struct {
 	Resources []Resource `json:"resources"`
+}
+
+// DescribeResourceParams is a type that contains the group, version, kind, name and
+// namespace of a resource to describe.
+type DescribeResourceParams struct {
+	GroupVersionKind
+	NamespacedNameParams
+}
+
+// DescribeResourceResult is a type that contains the human-readable description of a
+// resource, including its spec, status and related events, similar to `kubectl describe`.
+type DescribeResourceResult struct {
+	Description string `json:"description"`
+}
+
+// Describe renders the resource's identifying metadata, labels, annotations, spec,
+// status and events into r.Description as a human-readable string, similar to
+// `kubectl describe` output.
+func (r *DescribeResourceResult) Describe(resource *unstructured.Unstructured, events *corev1.EventList) {
+	buf := &bytes.Buffer{}
+	w := kubectldescribe.NewPrefixWriter(buf)
+
+	// writeMap writes a "<title>:" line with the first key=value pair on the
+	// header line and the rest indented below it, matching `kubectl describe`.
+	writeMap := func(title string, m map[string]string) {
+		if len(m) == 0 {
+			w.Write(kubectldescribe.LEVEL_0, "%s:\t<none>\n", title)
+			return
+		}
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		w.Write(kubectldescribe.LEVEL_0, "%s:\t%s=%s\n", title, keys[0], m[keys[0]])
+		for _, k := range keys[1:] {
+			w.Write(kubectldescribe.LEVEL_1, "%s=%s\n", k, m[k])
+		}
+	}
+
+	// writeYAML writes a "<title>:" section with data rendered as indented YAML.
+	writeYAML := func(title string, data any) {
+		yamlBytes, err := yaml.Marshal(data)
+		if err != nil {
+			w.Write(kubectldescribe.LEVEL_0, "%s:\t<error rendering: %v>\n", title, err)
+			return
+		}
+		trimmed := strings.TrimRight(string(yamlBytes), "\n")
+		if trimmed == "" || trimmed == "{}" {
+			w.Write(kubectldescribe.LEVEL_0, "%s:\t<none>\n", title)
+			return
+		}
+		w.Write(kubectldescribe.LEVEL_0, "%s:\n", title)
+		for _, line := range strings.Split(trimmed, "\n") {
+			w.Write(kubectldescribe.LEVEL_1, "%s\n", line)
+		}
+	}
+
+	w.Write(kubectldescribe.LEVEL_0, "Name:\t%s\n", resource.GetName())
+	if ns := resource.GetNamespace(); ns != "" {
+		w.Write(kubectldescribe.LEVEL_0, "Namespace:\t%s\n", ns)
+	}
+	w.Write(kubectldescribe.LEVEL_0, "Kind:\t%s\n", resource.GetKind())
+	if apiVersion := resource.GetAPIVersion(); apiVersion != "" {
+		w.Write(kubectldescribe.LEVEL_0, "API Version:\t%s\n", apiVersion)
+	}
+	writeMap("Labels", resource.GetLabels())
+	writeMap("Annotations", resource.GetAnnotations())
+
+	if spec, found, _ := unstructured.NestedFieldNoCopy(resource.Object, "spec"); found {
+		writeYAML("Spec", spec)
+	}
+	if status, found, _ := unstructured.NestedFieldNoCopy(resource.Object, "status"); found {
+		writeYAML("Status", status)
+	}
+
+	w.Write(kubectldescribe.LEVEL_0, "\n")
+	kubectldescribe.DescribeEvents(events, w)
+	w.Flush()
+
+	r.Description = buf.String()
 }

--- a/pkg/kubernetes/types/resources_test.go
+++ b/pkg/kubernetes/types/resources_test.go
@@ -1,0 +1,146 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestDescribeResourceResultDescribe(t *testing.T) {
+	tests := []struct {
+		testName        string
+		resource        *unstructured.Unstructured
+		events          *corev1.EventList
+		expectedContain []string
+		expectedOmit    []string
+	}{
+		{
+			testName: "namespaced resource with labels, spec, status and events",
+			resource: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]any{
+						"name":      "nginx",
+						"namespace": "default",
+						"labels":    map[string]any{"app": "nginx"},
+					},
+					"spec": map[string]any{
+						"nodeName": "worker-1",
+					},
+					"status": map[string]any{
+						"phase": "Running",
+						"podIP": "10.244.1.5",
+					},
+				},
+			},
+			events: &corev1.EventList{
+				Items: []corev1.Event{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "ev1"},
+						Type:       "Normal",
+						Reason:     "Scheduled",
+						Message:    "Successfully assigned default/nginx to worker-1",
+						Source:     corev1.EventSource{Component: "default-scheduler"},
+					},
+				},
+			},
+			expectedContain: []string{
+				"Name:\tnginx",
+				"Namespace:\tdefault",
+				"Kind:\tPod",
+				"API Version:\tv1",
+				"Labels:\tapp=nginx",
+				"Annotations:\t<none>",
+				"Spec:",
+				"nodeName: worker-1",
+				"Status:",
+				"phase: Running",
+				"podIP: 10.244.1.5",
+				"Events:",
+				"Scheduled",
+				"Successfully assigned default/nginx to worker-1",
+			},
+		},
+		{
+			testName: "resource without labels, spec, status or events shows <none>",
+			resource: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]any{
+						"name":      "empty",
+						"namespace": "default",
+					},
+				},
+			},
+			events: &corev1.EventList{},
+			expectedContain: []string{
+				"Name:\tempty",
+				"Labels:\t<none>",
+				"Annotations:\t<none>",
+				"Events:\t<none>",
+			},
+			expectedOmit: []string{"Spec:", "Status:"},
+		},
+		{
+			testName: "cluster-scoped resource omits Namespace line",
+			resource: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Node",
+					"metadata": map[string]any{
+						"name": "worker-0",
+					},
+				},
+			},
+			events: &corev1.EventList{},
+			expectedContain: []string{
+				"Name:\tworker-0",
+				"Kind:\tNode",
+			},
+			expectedOmit: []string{"Namespace:\t"},
+		},
+		{
+			testName: "multiple labels are sorted, first on the header line",
+			resource: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]any{
+						"name": "multi-label",
+						"labels": map[string]any{
+							"zeta":  "z",
+							"alpha": "a",
+						},
+					},
+				},
+			},
+			events: &corev1.EventList{},
+			expectedContain: []string{
+				"Labels:\talpha=a",
+				"zeta=z",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			result := DescribeResourceResult{}
+			result.Describe(test.resource, test.events)
+			for _, want := range test.expectedContain {
+				if !strings.Contains(result.Description, want) {
+					t.Errorf("expected description to contain %q, got:\n%s", want, result.Description)
+				}
+			}
+			for _, notWant := range test.expectedOmit {
+				if strings.Contains(result.Description, notWant) {
+					t.Errorf("expected description to not contain %q, got:\n%s", notWant, result.Description)
+				}
+			}
+		})
+	}
+}

--- a/pkg/middleware/toolfilter/toolfilter.go
+++ b/pkg/middleware/toolfilter/toolfilter.go
@@ -17,7 +17,7 @@ import (
 // pkg/*/mcp/mcp.go; the README "Tools available in MCP Server" table is the
 // canonical reference.
 var toolsByCategory = map[string][]string{
-	"kubernetes":    {"pod-logs", "resource-get", "resource-list"},
+	"kubernetes":    {"pod-logs", "resource-get", "resource-list", "resource-describe"},
 	"ovn":           {"ovn-show", "ovn-get", "ovn-lflow-list", "ovn-trace"},
 	"ovs":           {"ovs-vsctl", "ovs-ofctl", "ovs-appctl"},
 	"kernel":        {"get-conntrack", "get-iptables", "get-nft", "get-ip"},

--- a/test/e2e/kubernetes_test.go
+++ b/test/e2e/kubernetes_test.go
@@ -19,8 +19,9 @@ import (
 
 var _ = Describe("Kubernetes Tools", func() {
 	const (
-		resourceGetToolName  = "resource-get"
-		resourceListToolName = "resource-list"
+		resourceGetToolName      = "resource-get"
+		resourceListToolName     = "resource-list"
+		resourceDescribeToolName = "resource-describe"
 	)
 
 	fr := k8se2eframework.NewDefaultFramework("kubernetes-tools")
@@ -167,6 +168,53 @@ var _ = Describe("Kubernetes Tools", func() {
 				cmpopts.IgnoreFields(types.Resource{}, "FormattedOutput.Data"),
 			}
 			Expect(cmp.Equal(listResult, expectedListResult, cmpOptions)).To(BeTrue())
+		})
+	})
+
+	Context("Describe Resource", func() {
+		It("should describe a secret from a namespace", func() {
+			By("Creating a secret")
+			secretName := "test-describe-secret"
+			err := kubeClient.Create(context.Background(), &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: fr.Namespace.Name,
+					Labels:    map[string]string{"app": "test-describe"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Describing the secret")
+			output, err := mcpInspector.
+				MethodCall(resourceDescribeToolName, map[string]any{
+					"group":     "",
+					"version":   "v1",
+					"kind":      "Secret",
+					"namespace": fr.Namespace.Name,
+					"name":      secretName,
+				}).Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty())
+
+			By("Checking the description contains identifying metadata and an events section")
+			describeResult := utils.UnmarshalCallToolResult[types.DescribeResourceResult](output)
+			Expect(describeResult.Description).To(ContainSubstring("Name:\t" + secretName))
+			Expect(describeResult.Description).To(ContainSubstring("Namespace:\t" + fr.Namespace.Name))
+			Expect(describeResult.Description).To(ContainSubstring("Kind:\tSecret"))
+			Expect(describeResult.Description).To(ContainSubstring("app=test-describe"))
+			Expect(describeResult.Description).To(ContainSubstring("Events:"))
+		})
+
+		It("should return an error when the resource does not exist", func() {
+			By("Describing a resource that does not exist")
+			_, err := mcpInspector.
+				MethodCall(resourceDescribeToolName, map[string]any{
+					"version":   "v1",
+					"kind":      "Secret",
+					"namespace": fr.Namespace.Name,
+					"name":      "does-not-exist",
+				}).Execute()
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
Add a resource-describe MCP tool that renders a resource's spec, status and related Events similar to `kubectl describe`, so agents can see *why* a resource is failing (scheduling, image pull, probe, policy denials) rather than just its current state.

Closes ovn-kubernetes/ovn-kubernetes-mcp #23