### PR TITLE
add --stateless option for HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The server currently supports 2 transport modes: `stdio` and `http`.
 | `--transport` | `stdio`                         | Transport: `stdio` or `http`. |
 | `--host` | `localhost`                     | Address the HTTP server binds to (`http` only). Use `0.0.0.0` in a container so clients can reach the listener. |
 | `--port` | `8080`                          | Port for HTTP transport. |
+| `--stateless` | `true`                          | Skip `Mcp-Session-Id` validation and serve each request on a temporary session (`http` only). Required behind a proxy and when running more than one replica, since neither guarantees a request returns to the process that issued the session. In this mode `GET` returns `405` (no SSE stream). Set to `false` only for clients that need SSE. |
 | `--kubeconfig` | (none)                          | Path to kubeconfig file. Omit when using in-cluster **ServiceAccount** credentials (for example the pod deployment); otherwise set for `live-cluster` and `dual`. |
 | `--pwru-image` | `docker.io/cilium/pwru:v1.0.10` | Container image for the **pwru** network tool (kernel packet tracing). |
 | `--tcpdump-image` | `nicolaka/netshoot:v0.15`       | Container image for the **tcpdump** network tool (packet capture). |

--- a/cmd/ovnk-mcp-server/main.go
+++ b/cmd/ovnk-mcp-server/main.go
@@ -40,6 +40,7 @@ type MCPServerConfig struct {
 	Kubernetes    kubernetesmcp.Config
 	ToolTimeout   time.Duration
 	DisabledTools map[string]bool
+	Stateless     bool
 }
 
 // setupLiveCluster sets up the live cluster mode.
@@ -162,9 +163,12 @@ func main() {
 			log.Printf("Server failed: %v", err)
 		}
 	case "http":
+		// Stateless because proxies and extra replicas serve requests on
+		// transports that never saw the matching Mcp-Session-Id.
 		handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 			return ovnkMcpServer
-		}, nil)
+		}, &mcp.StreamableHTTPOptions{Stateless: serverCfg.Stateless})
+		log.Printf("HTTP transport stateless mode: %v", serverCfg.Stateless)
 		addr := net.JoinHostPort(serverCfg.Host, serverCfg.Port)
 		log.Printf("Listening on %s", addr)
 		server = &http.Server{
@@ -195,6 +199,8 @@ func parseFlags() *MCPServerConfig {
 	flag.StringVar(&cfg.Transport, "transport", "stdio", "Transport to use: stdio or http")
 	flag.StringVar(&cfg.Host, "host", "localhost", "Host to bind to (use 0.0.0.0 for container/cluster)")
 	flag.StringVar(&cfg.Port, "port", "8080", "Port to use")
+	flag.BoolVar(&cfg.Stateless, "stateless", true,
+		"For http transport, skip Mcp-Session-Id validation. Disable only for clients needing SSE (GET)")
 	flag.StringVar(&cfg.Kubernetes.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 	flag.StringVar(&cfg.NetworkTools.PwruImage, "pwru-image", "docker.io/cilium/pwru:v1.0.10", "Container image for pwru operations")
 	flag.StringVar(&cfg.NetworkTools.TcpdumpImage, "tcpdump-image", defaultNetshootImage, "Container image for tcpdump operations")


### PR DESCRIPTION
Session state lives in the process that served initialize, so a request carrying an `Mcp-Session-Id` issued elsewhere is refused with "session not found". That makes session affinity a correctness requirement: scaling `config/deployment.yaml` past one replica breaks because `config/service.yaml` sets no `sessionAffinity`, and any proxy that forwards a request on a fresh transport fails the same way.

Pass `StreamableHTTPOptions.Stateless` when building the handler, behind a `--stateless` flag. It defaults to `false` so today's session-managed behavior is unchanged; deployments behind a proxy or running more than one replica set it to `true`. In stateless mode `GET` returns `405` and server-to-client requests are refused, so clients that need either must leave it off.

closes issue #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional stateless HTTP mode for the MCP server, disabled by default.
  * Stateless mode skips session ID validation and handles each request with a temporary session.
  * Added the `-stateless` command-line option to enable this mode.
  * In stateless mode, HTTP `GET` requests return `405 Method Not Allowed`, and server-to-client requests are unavailable.

* **Documentation**
  * Documented the stateless HTTP option and its limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->